### PR TITLE
85 improve geom pop function allow to draw key and add logic of facets

### DIFF
--- a/R/geom_pop.R
+++ b/R/geom_pop.R
@@ -35,10 +35,16 @@ geom_pop <- function(mapping = NULL, data = NULL, stat = "identity",
                      group_var = NULL, sample_size = NULL, arrange = FALSE, sum_var = NULL,
                      facet=NULL,
                      size = 1, # default size as 1 externally
+                     legend_icons = FALSE,
                      ...) {
-  
   # Transform the user-specified size to the desired internal scale
   # If user specifies 1, internally we use 0.03
+  if (is.null(data)) {
+    #inherit from the main ggplot aes
+    data <- ggplot_build(last_plot())$plot$data
+  }    
+  
+  
   size_internal <- size * 0.03
   
   # Convert mapping to a list
@@ -51,6 +57,18 @@ geom_pop <- function(mapping = NULL, data = NULL, stat = "identity",
   if (!"icon" %in% names(mapping_list)) {
     mapping_list[["icon"]] <- icon
   }
+  
+  data <- data %>% mutate(pos = as.numeric(row_number()))
+  
+  sample_size <- length(unique(data$pos))
+  
+  df_coordinates_final <- fetch_df_coordinates()
+  
+  df_coordinates_filtered <- df_coordinates_final %>%
+    filter(size == sample_size)
+  
+  df_merged <- left_join(df_coordinates_filtered, data, by = "pos")
+  
   if (!is.null(data) && arrange && is.null(facet)) {
     
     df_order <- data %>% select(n , prop)
@@ -61,14 +79,27 @@ geom_pop <- function(mapping = NULL, data = NULL, stat = "identity",
       mutate(pos = row_number()) %>%
       select(-original_order, -n , -prop)
     
-    data <- bind_cols(data, df_order) } 
+    data <- bind_cols(data, df_order) 
+    
+    sample_size <- length(unique(data$pos))
+    
+    df_coordinates_final <- fetch_df_coordinates()
+    
+    df_coordinates_filtered <- df_coordinates_final %>%
+      filter(size == sample_size)
+    
+    df_merged <- left_join(df_coordinates_filtered, data, by = "pos")
+    
+  } 
   else if (!is.null(data) && arrange && !is.null(facet)) {
     facet_var <- substitute(facet)
     
     df_order <- data %>% select(n , prop)
     
     data <- data %>%
-      mutate(original_order = pos) %>% 
+      group_by(!!facet_var) %>%
+      mutate(original_order = row_number()) %>%
+      ungroup() %>%
       arrange(type, original_order, !!facet_var) %>%  # Sort by the specified columns
       group_by(!!facet_var) %>%  # Group by the specified column
       mutate(pos = row_number()) %>%  # Calculate a sequential row number without restarting
@@ -78,16 +109,59 @@ geom_pop <- function(mapping = NULL, data = NULL, stat = "identity",
     
     data <- bind_cols(data, df_order)
     
+    #sample_size <- length(unique(data$pos))
+    sample_size <- data %>%
+      group_by(!!facet_var) %>%
+      summarise(sample_size = n_distinct(pos), .groups = "drop")
+    
+    df_coordinates_final <- fetch_df_coordinates()
+    
+    df_coordinates_filtered <- df_coordinates_final %>%
+      rowwise() %>%
+      filter(size %in% sample_size$sample_size) %>%
+      ungroup()
+    
+    # Evaluate facet_var and join sample_size
+    facet_col <- as.character(facet_var)
+    data <- data %>%
+      left_join(sample_size %>% rename(size = sample_size), by = facet_col)
+    
+    # Ensure consistent data types
+    data$size <- as.character(data$size)
+    
+    df_merged <- left_join(df_coordinates_filtered, data, by = c("pos", "size"))
+    
+  } else if (!is.null(data) && !arrange && !is.null(facet)) {
+    facet_var <- substitute(facet)
+    
+    data <- data %>%
+      group_by(!!facet_var) %>%
+      mutate(pos = row_number()) %>%
+      ungroup()
+    
+    #sample_size <- length(unique(data$pos))
+    sample_size <- data %>%
+      group_by(!!facet_var) %>%
+      summarise(sample_size = n_distinct(pos), .groups = "drop")
+    
+    df_coordinates_final <- fetch_df_coordinates()
+    
+    df_coordinates_filtered <- df_coordinates_final %>%
+      rowwise() %>%
+      filter(size %in% sample_size$sample_size) %>%
+      ungroup()
+    
+    # Evaluate facet_var and join sample_size
+    facet_col <- as.character(facet_var)
+    data <- data %>%
+      left_join(sample_size %>% rename(size = sample_size), by = facet_col)
+    
+    # Ensure consistent data types
+    data$size <- as.character(data$size)
+    
+    df_merged <- left_join(df_coordinates_filtered, data, by = c("pos", "size"))
+    
   }
-  
-  sample_size <- length(unique(data$pos))
-  
-  df_coordinates_final <- fetch_df_coordinates()
-  
-  df_coordinates_filtered <- df_coordinates_final %>%
-    filter(size == sample_size)
-  
-  df_merged <- left_join(df_coordinates_filtered, data, by = "pos")
   
   # Get the row count of the merged table
   N <- nrow(df_merged)
@@ -108,20 +182,37 @@ geom_pop <- function(mapping = NULL, data = NULL, stat = "identity",
   }
   
   icon_expr <- mapping_list[["icon"]]
-  mapping_list[["image"]] <- bquote(paste0("man/figures/", .(icon_expr), ".svg"))
+  mapping_list[["image"]] <- bquote(paste0("inst/figures/", .(icon_expr), ".svg"))
   
-  final_mapping <- do.call(aes_, mapping_list)
+  final_mapping <- do.call(aes, mapping_list)
   final_mapping$x <- as.name("x1")
   final_mapping$y <- as.name("y1")
   
-  ggimage::geom_image(
-    mapping = final_mapping,
-    data = df_final,
-    stat = stat,
-    position = position,
-    na.rm = na.rm,
-    inherit.aes = inherit.aes,
-    size = size_internal,
-    ...
-  )
+  if (legend_icons) {
+    ggimage::geom_image(
+      mapping = final_mapping,
+      data = df_final,
+      stat = stat,
+      position = position,
+      na.rm = na.rm,
+      inherit.aes = inherit.aes,
+      size = size_internal,     # <--- here
+      key_glyph = draw_key_pop_image,
+      ...
+    )
+  } else {
+    
+    ggimage::geom_image(
+      mapping = final_mapping,
+      data = df_final,
+      stat = stat,
+      position = position,
+      na.rm = na.rm,
+      inherit.aes = inherit.aes,
+      size = size_internal,     # <--- here
+      #key_glyph = draw_key_standard_point,    
+      ...
+    )
+  }
 }
+


### PR DESCRIPTION
#85 #77 

- Fixed a bug that prevented proper arrangement of plots when `facet_wrap` or `facet_grid` was used.

- Resolved a problem where grouping variables in faceted plots could lead to mismatches during the data merge step.

- **Introduced the `legend_icons` parameter in `geom_pop` to allow users to include custom icons within the legend without hiding the entire legend.** This enhancement provides greater flexibility in customizing legends, enabling the display of representative images alongside group labels for more informative and visually appealing plots.