### PR TITLE
104 fix scale legend icon function bug

### DIFF
--- a/R/scale_legend_icon.R
+++ b/R/scale_legend_icon.R
@@ -26,7 +26,7 @@ scale_legend_icon <- function(size = 10, ...) {
   # type
   types <- levels(factor(data$type))
   
-  # icon
+  # icons
   icons <- sapply(types, function(t) {
     idx <- which(data$type == t)
     data$icon[idx[1]]


### PR DESCRIPTION
#100 
This pull request includes changes to the `scale_legend_icon` function in the `R/scale_legend_icon.R` file to improve data retrieval and processing.

Improvements to data retrieval and processing:

* Changed the method of retrieving the plot data by storing the last plot object in `gg_obj` and then accessing its data through `gg_obj$layers[[1]]$data`. This improves clarity and ensures the correct data layer is accessed.
* Added a new line at the end of the function to follow best practices for code formatting.