### PR TITLE
Fix documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Imports:
     rlang,
     tidyr,
     purrr,
-    ggtext
+    ggtext,
+    fontawesome
 ByteCompile: true
 BugReports: https://github.com/jurjoroa/ggpop/issues

--- a/man/draw_key_pop_image.Rd
+++ b/man/draw_key_pop_image.Rd
@@ -19,12 +19,14 @@ and an \code{icon} column with the names of the icon files (without extension) t
 A grid grob containing the image icons with the specified colors and transparency.
 }
 \description{
+Key drawing function for population-based image keys
+}
+\details{
 This function creates a custom key for displaying population-based image icons
 in the legend of a ggplot2 plot. Each group can be assigned a different icon
 based on the information in the \code{data$icon} column, and the icons can be colorized
 according to the specified \code{colour} and \code{alpha} aesthetics.
-}
-\details{
+
 This function relies on \code{ggimage:::color_image} and \code{ggplot2:::ggname}, which are internal functions.
 Their use is necessary for correct functionality, and no exported alternatives exist.
 We acknowledge the potential risks associated with \code{:::} usage, but at present, these functions

--- a/man/ggpop-package.Rd
+++ b/man/ggpop-package.Rd
@@ -18,5 +18,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Jorge Roa \email{jorgeroa@stanford.edu} (\href{https://orcid.org/0000-0002-3972-9793}{ORCID})
 
+Authors:
+\itemize{
+  \item Carlos Pineda-Antunez \email{cpinedaa@uw.edu} (\href{https://orcid.org/0000-0002-8352-7080}{ORCID})
+  \item Fernando Alarid-Escudero \email{falarid@stanford.edu} (\href{https://orcid.org/0000-0001-5076-1172}{ORCID})
+}
+
 }
 \keyword{internal}


### PR DESCRIPTION
The most important changes include adding a new package dependency, updating documentation for a key drawing function, and adding new authors to the package documentation.

### Enhancements and Updates:

* [`DESCRIPTION`](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL39-R40): Added `fontawesome` to the list of imported packages.
* [`man/draw_key_pop_image.Rd`](diffhunk://#diff-290b73f218cf8139bc62721a2474747ea71b18db85e2ead168ea9844142d797cR22-R29): Added a detailed description for the key drawing function for population-based image keys in the documentation.
* [`man/ggpop-package.Rd`](diffhunk://#diff-6f03759ff16a5b5349e628c8a76fd4f677449013ac97cfbecb52489111fc5240R21-R26): Added Carlos Pineda-Antunez and Fernando Alarid-Escudero as authors in the package documentation.


Issue: #120

Version: #118