### PR TITLE
Update draw_key.R

### DIFF
--- a/R/draw_key.R
+++ b/R/draw_key.R
@@ -22,7 +22,7 @@
 #' We acknowledge the potential risks associated with `:::` usage, but at present, these functions
 #' provide essential behavior for rendering images within ggplot2.
 ##' @export
-ddraw_key_pop_image <- function(data, params, size) {
+draw_key_pop_image <- function(data, params, size) {
   
   grobs <- lapply(seq_along(data$colour), function(i) {
     


### PR DESCRIPTION
This pull request includes a minor but important change to the `R/draw_key.R` file. The change renames the function `ddraw_key_pop_image` to `draw_key_pop_image` for consistency and to align with naming conventions.


Issue: #159

Version: #154