### PR TITLE
205 fix bug scale legend icon is cutting margins

### DIFF
--- a/R/scale_legend_icon.R
+++ b/R/scale_legend_icon.R
@@ -22,6 +22,7 @@ ggplot_add.ggpop_legend_icon <- function(object, plot, ...) {
   if (is.null(object$margin)) object$margin <- ggplot2::margin(0, 0, 0, 0)
   
   key_mm <- object$size
+  
   if (!is.numeric(key_mm) || length(key_mm) != 1 || is.na(key_mm) || key_mm <= 0) key_mm <- 10
   
   # Apply the theme changes now


### PR DESCRIPTION
This pull request makes a small adjustment to the default margin applied to legend icons in the `ggpop_legend_icon` ggplot2 extension. The bottom margin is now set to 0 instead of 30, which will remove extra space below legend icons by default.

* Reduced the default bottom margin for legend icons from 30 to 0 in `ggplot_add.ggpop_legend_icon`, resulting in tighter legend layouts.

Issue: [#205](https://github.com/jurjoroa/ggpop/issues/205)

Version: [#211](https://github.com/jurjoroa/ggpop/issues/211)