### PR TITLE
Update pkgdown workflow branches

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main, Dev]
   pull_request:
   release:
     types: [published]


### PR DESCRIPTION
Change push trigger branches in .github/workflows/pkgdown.yaml from [main, master] to [main, Dev] so pkgdown builds run on pushes to the Dev branch (in addition to main).

Issue: #237

Version: #236