### PR TITLE
Add input validation and robustness to process_data

### DIFF
--- a/R/process_data.R
+++ b/R/process_data.R
@@ -26,9 +26,27 @@
 
 process_data <- function(data, 
                          high_group_var = NULL, 
-                         group_var = NULL, 
+                         group_var, 
                          sum_var = NULL, 
                          sample_size = 100) {
+  
+  # ---- VALIDATE data ----
+  if (is.null(data)) {
+    stop("Argument 'data' is required and cannot be NULL.", call. = FALSE)
+  }
+  
+  if (!inherits(data, c("data.frame", "data.table", "tbl_df", "tbl"))) {
+    stop("Argument 'data' must be a data.frame, data.table, or tibble.", call. = FALSE)
+  }
+  
+  if (nrow(data) == 0) {
+    stop("Argument 'data' cannot be empty (0 rows).", call. = FALSE)
+  }
+  
+  # Check if data has at least one column
+  if (ncol(data) == 0) {
+    stop("Argument 'data' must have at least one column.", call. = FALSE)
+  }
   
   # ---- VALIDATE sample_size ----
   if (!is.numeric(sample_size) || length(sample_size) != 1L || is.na(sample_size) ||
@@ -37,14 +55,115 @@ process_data <- function(data,
   }
   sample_size <- as.integer(sample_size)
   
+  # ---- VALIDATE group_var ----
+  group_var_sym <- tryCatch(
+    rlang::enquo(group_var),
+    error = function(e) {
+      if (grepl("missing", e$message)) {
+        stop("Please provide a 'group_var'.", call. = FALSE)
+      } else {
+        stop(e$message, call. = FALSE)
+      }
+    }
+  )
   
-  # --- Capture arguments properly ---
-  group_var_sym <- rlang::enquo(group_var)     # Capture unquoted
-  sum_var_sym   <- rlang::enquo(sum_var)       # Capture unquoted
+  if (rlang::quo_is_null(group_var_sym) || 
+      rlang::quo_is_missing(group_var_sym) ||
+      rlang::as_label(group_var_sym) == "" ||
+      rlang::as_label(group_var_sym) == "NULL") {
+    stop("Please provide a valid 'group_var'.", call. = FALSE)
+  }
   
-  # Error if no group_var is provided
-  if (rlang::quo_is_missing(group_var_sym) || rlang::as_label(group_var_sym) == "") {
-    stop("Please provide a 'group_var'.")
+  # Check if group_var exists in data
+  group_var_name <- rlang::as_label(group_var_sym)
+  if (!group_var_name %in% names(data)) {
+    stop("`group_var` '", group_var_name, "' not found in data.", call. = FALSE)
+  }
+  
+  # Check if group_var has at least one non-NA value
+  if (all(is.na(data[[group_var_name]]))) {
+    stop("`group_var` '", group_var_name, "' contains only NA values.", call. = FALSE)
+  }
+  
+  # Check if group_var has at least 2 unique values
+  unique_groups <- length(unique(data[[group_var_name]][!is.na(data[[group_var_name]])]))
+  if (unique_groups < 1) {
+    stop("`group_var` '", group_var_name, "' must have at least one unique value.", call. = FALSE)
+  }
+  
+  # ---- VALIDATE high_group_var ----
+  if (!is.null(high_group_var)) {
+    # NEW: Check if high_group_var is character vector
+    if (!is.character(high_group_var)) {
+      stop("`high_group_var` must be a character vector.", call. = FALSE)
+    }
+    
+    # Check if all high_group_var columns exist in data
+    missing_cols <- high_group_var[!high_group_var %in% names(data)]
+    if (length(missing_cols) > 0) {
+      stop("`high_group_var` column(s) not found in data: ", 
+           paste(missing_cols, collapse = ", "), call. = FALSE)
+    }
+    
+    # Check if high_group_var contains group_var
+    if (group_var_name %in% high_group_var) {
+      stop("`high_group_var` cannot contain the same variable as `group_var` ('", 
+           group_var_name, "').", call. = FALSE)
+    }
+    
+    # Check for duplicates in high_group_var
+    if (any(duplicated(high_group_var))) {
+      stop("`high_group_var` contains duplicate column names.", call. = FALSE)
+    }
+    
+    # Warn if high_group_var has all NA values in any column
+    for (col in high_group_var) {
+      if (all(is.na(data[[col]]))) {
+        warning("`high_group_var` column '", col, "' contains only NA values.", 
+                call. = FALSE)
+      }
+    }
+  }
+  
+  # ---- VALIDATE sum_var ----
+  sum_var_sym <- rlang::enquo(sum_var)
+  
+  if (!rlang::quo_is_null(sum_var_sym)) {
+    sum_var_name <- rlang::as_label(sum_var_sym)
+    
+    if (!sum_var_name %in% names(data)) {
+      stop("`sum_var` '", sum_var_name, "' not found in data.", call. = FALSE)
+    }
+    
+    if (!is.numeric(data[[sum_var_name]])) {
+      stop("`sum_var` must be a numeric column. Column '", 
+           sum_var_name, "' is of type '", 
+           class(data[[sum_var_name]])[1], "'.", call. = FALSE)
+    }
+    
+    # Check for NAs and warn
+    if (any(is.na(data[[sum_var_name]]))) {
+      warning("`sum_var` '", sum_var_name, "' contains NA values. These will be excluded from calculations.", 
+              call. = FALSE)
+    }
+    
+    # Check for all zeros or all NAs
+    sum_values <- sum(data[[sum_var_name]], na.rm = TRUE)
+    if (sum_values == 0 || is.na(sum_values)) {
+      stop("`sum_var` cannot be all zeros or all NAs. Cannot compute proportions.", 
+           call. = FALSE)
+    }
+    
+    # Check for negative values
+    if (any(data[[sum_var_name]] < 0, na.rm = TRUE)) {
+      warning("`sum_var` '", sum_var_name, "' contains negative values.", 
+              call. = FALSE)
+    }
+    
+    # Check if sum_var is the same as group_var
+    if (sum_var_name == group_var_name) {
+      stop("`sum_var` cannot be the same as `group_var`.", call. = FALSE)
+    }
   }
   
   # Generate a random seed
@@ -65,7 +184,7 @@ process_data <- function(data,
   df_proportion <- data %>%
     # Convert group_var to character
     mutate(
-      !!group_var_sym == as.character(!!group_var_sym)
+      !!group_var_sym := as.character(!!group_var_sym)
     ) %>%
     # Group by high_group_var + group_var
     {
@@ -82,7 +201,7 @@ process_data <- function(data,
       n = if (rlang::quo_is_null(sum_var_sym)) {
         n() 
       } else {
-        sum(!!sum_var_sym)
+        sum(!!sum_var_sym, na.rm = TRUE)
       },
       .groups = 'drop'
     ) %>%
@@ -96,21 +215,28 @@ process_data <- function(data,
       }
     } %>%
     mutate(prop = n / sum(n)) %>%
-    ungroup()
+    ungroup() %>%
+    # Filter out invalid proportions
+    filter(!is.na(prop), prop > 0, is.finite(prop))
   
   # Optional: Validate that proportions sum to 1
+  # REPLACE THIS ENTIRE SECTION:
   if (!is.null(higher_group_syms)) {
     validation <- df_proportion %>%
       group_by(across(all_of(high_group_var))) %>%
-      summarise(total_prop = sum(prop), .groups = "drop")
+      summarise(total_prop = sum(prop, na.rm = TRUE), .groups = "drop")  # <-- CHANGED
     
-    if (any(abs(validation$total_prop - 1) > 1e-6)) {
-      warning("Proportions within some groups do not sum to 1.")
+    # Check if any proportions don't sum to 1 (excluding NAs)
+    invalid_props <- validation$total_prop[!is.na(validation$total_prop)]  # <-- CHANGED
+    if (length(invalid_props) > 0 && any(abs(invalid_props - 1) > 1e-6)) {  # <-- CHANGED
+      warning("Proportions within some groups do not sum to 1.", call. = FALSE)
     }
   } else {
-    total_prop <- sum(df_proportion$prop)
-    if (abs(total_prop - 1) > 1e-6) {
-      warning("Proportions do not sum to 1.")
+    total_prop <- sum(df_proportion$prop, na.rm = TRUE)  # <-- CHANGED
+    
+    # Only check if total_prop is not NA
+    if (!is.na(total_prop) && abs(total_prop - 1) > 1e-6) {  # <-- CHANGED
+      warning("Proportions do not sum to 1.", call. = FALSE)
     }
   }
   


### PR DESCRIPTION
Add comprehensive input validation and safer computations in process_data: check that `data` is non-NULL, non-empty and a data.frame/data.table/tibble; require and validate `group_var` (presence in data, non-NA values); validate `high_group_var` (type, existence, duplicates, NA columns) and `sum_var` (exists, numeric, non-zero sum, NA/negative checks). Improve quosure handling, change mutate to use := for assigning character group values, use na.rm in summaries (sum), filter out invalid proportions, and make proportion-sum checks more robust (use na.rm, ignore NA groups). Error/warning messages are more informative and use call. = FALSE.

Issue: #243

Version: #236