### PR TITLE
Add pkgdown site theme, navbar and content

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,67 @@
 url: https://jurjoroa.github.io/ggpop/
 template:
   bootstrap: 5
+  bslib:
+    bg: "#01394f"
+    fg: "white"
+    primary: "#FF6B6B"
+    #navbar-light-bg: "#9CBAE7"
+    #navbar-dark-bg: "#183663"
+  includes:
+    in_header: |
+      <link rel="stylesheet" href="extra.css">
 
+navbar:
+  title: 'ggpop'
+  left:
+    - icon: fa-home fa-lg
+      href: index.html
+    - text: "Vignettes"
+      href: articles/index.html
+    - text: "Functions"
+      href: reference/index.html
+    - text: "News"
+      href: news/index.html
+    - text: "Other Packages"
+      menu:
+        - text: "rstan"
+          href: https://mc-stan.org/rstan
+        - text: "cmdstanr"
+          href: https://mc-stan.org/cmdstanr
+        - text: "rstanarm"
+          href: https://mc-stan.org/rstanarm
+        - text: "shinystan"
+          href: https://mc-stan.org/shinystan
+        - text: "loo"
+          href: https://mc-stan.org/loo
+        - text: "projpred"
+          href: https://mc-stan.org/projpred
+        - text: "rstantools"
+          href: https://mc-stan.org/rstantools
+        - text: "posterior"
+          href: https://mc-stan.org/posterior
+    - text: "Stan"
+      href: https://mc-stan.org
+  right:
+   - icon: fa-twitter
+     href: https://twitter.com/mcmc_stan
+   - icon: fa-github
+     href: https://github.com/stan-dev/bayesplot
+   - icon: fa-users
+     href: https://discourse.mc-stan.org/
+  
+home:
+  links:
+  - text: Ask a question
+    href: https://discourse.mc-stan.org/
+
+articles:
+  - title: "Getting Started"
+    desc: >
+      These vignettes provide an introduction to visualizing MCMC draws and
+      diagnostics and performing graphical posterior predictive checks using
+      the **bayesplot** package.
+    contents:
+      - plotting-mcmc-draws
+      - visual-mcmc-diagnostics
+      - graphical-ppcs


### PR DESCRIPTION
Enhance pkgdown site configuration: add bslib theme colors and include extra.css, configure a custom navbar with left links (vignettes, reference, news, Other Packages menu) and right social icons, and add home links and article metadata for a "Getting Started" vignette set. This organizes site navigation and applies a consistent visual theme for the ggpop pkgdown site.

Issue: #246

Version: #236