### PR TITLE
Unignore docs/inst/figures/logo.png

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .github/pull_request_template.md
 
 docs
+!docs/inst/figures/logo.png


### PR DESCRIPTION
Add a negation rule to .gitignore so docs/inst/figures/logo.png is tracked. The docs directory remains ignored, but this specific logo file will be included in the repository (useful for packaging or displaying the project logo).

Issue: #246

Version: #236