### PR TITLE
Allow tracking docs/inst/figures in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,9 @@
 .Ruserdata
 .github/pull_request_template.md
 
-docs
-!docs/inst/figures/logo.png
+# Allow tracking docs/inst/figures/ on Dev
+docs/*
+!docs/inst/
+docs/inst/*
+!docs/inst/figures/
+!docs/inst/figures/*.png


### PR DESCRIPTION
Update .gitignore to ignore docs/* while explicitly unignoring docs/inst/ and docs/inst/figures/, including all PNG files. Replaces the previous single exception for docs/inst/figures/logo.png so additional figure images can be tracked.