### PR TITLE
Ignore docs in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .Ruserdata
 .github/pull_request_template.md
 
+# Ignore ALL docs on main (CRAN clean)
+docs


### PR DESCRIPTION
Add 'docs' to .gitignore to prevent committing generated documentation on the main branch (keeps CRAN-related artifacts out of the repo). Includes a comment explaining the intent.