### PR TITLE
Validate mixed legend_icons in ggplot_add

### DIFF
--- a/R/geom_icon_point.R
+++ b/R/geom_icon_point.R
@@ -100,7 +100,6 @@ geom_icon_point <- function(mapping = NULL, data = NULL, stat = "identity",
   # ==============================================================================
   warn_size_conflict(combined_mapping, .missing_size, size)
   warn_alpha_conflict(combined_mapping, extra_args)
-  warn_mixed_legend_icons(legend_icons)
   
   # ==============================================================================
   # ICON HANDLING
@@ -455,10 +454,13 @@ geom_icon_point <- function(mapping = NULL, data = NULL, stat = "identity",
     ...
   )
   
-  # Pass params to layer for key glyph access
   layer_out$geom_params$icon_by_legend <- icon_by_legend
   layer_out$geom_params$plot_obj <- plot_obj
   layer_out$geom_params$dpi <- dpi
+  
+  layer_out$ggpop_layer_type <- "icon_point"
+  layer_out$ggpop_legend_icons <- isTRUE(legend_icons)
+  class(layer_out) <- c("ggpop_icon_point_layer", class(layer_out))
   
   layer_out
 }

--- a/R/scale_legend_icon.R
+++ b/R/scale_legend_icon.R
@@ -55,3 +55,33 @@ ggplot_add.ggpop_geom_pop <- function(object, plot, object_name, ...) {
 
   plot
 }
+
+
+#' @export
+ggplot_add.ggpop_icon_point_layer <- function(object, plot, object_name) {
+  plot$layers <- append(plot$layers, list(object))
+  
+  vals <- vapply(plot$layers, function(l) {
+    if (inherits(l, "ggpop_icon_point_layer") &&
+        identical(l$ggpop_layer_type, "icon_point")) {
+      isTRUE(l$ggpop_legend_icons)
+    } else {
+      NA
+    }
+  }, logical(1), USE.NAMES = FALSE)
+  
+  vals <- vals[!is.na(vals)]
+  
+  if (length(vals) > 1 && any(vals) && any(!vals)) {
+    cli::cli_abort(
+      c(
+        "{.fn geom_icon_point}: mixed {.field legend_icons} settings detected.",
+        "x" = "Some {.fn geom_icon_point} layers use {.val TRUE} and others use {.val FALSE}.",
+        "i" = "Use consistent settings across all {.fn geom_icon_point} layers."
+      ),
+      call = NULL
+    )
+  }
+  
+  plot
+}


### PR DESCRIPTION
Remove the in-function warn_mixed_legend_icons call from geom_icon_point and attach metadata to the generated layer (ggpop_layer_type, ggpop_legend_icons) and a specific class (ggpop_icon_point_layer). Add ggplot_add.ggpop_icon_point_layer to perform a cross-layer check for inconsistent legend_icons settings and abort with a clear error if mixed values are found. This moves the validation to the plot-add hook so it can consider all layers when deciding whether to error.

Issue: #258

Version: #236