### PR TITLE
Remove header include and fix pkgdown logo link

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,9 +6,6 @@ template:
     fg: "white"
     primary: "#FF6B6B"
   assets: pkgdown/assets
-  includes:
-    in_header: |
-      <link rel="stylesheet" href="extra.css">
 
 navbar:
   title: 'ggpop'
@@ -55,7 +52,7 @@ footer:
     left: [package_logo, developed_by]
     right: built_with
   components:
-    package_logo: "<a href='index.html'><img src='inst/figures/shp.png' height='40' alt='ggpop' style='vertical-align: middle; margin-right: 6px;'></a>"
+    package_logo: "<a href='https://jurjoroa.github.io/ggpop/'><img src='https://jurjoroa.github.io/ggpop/inst/figures/shp.png' height='40' alt='ggpop' style='vertical-align: middle; margin-right: 6px;'></a>"
 
 articles:
   - title: "Data Preparation"


### PR DESCRIPTION
Remove the in_header include that added extra.css to the pkgdown template, and update the footer package_logo anchor and image src to absolute GitHub Pages URLs (https://jurjoroa.github.io/ggpop/). Ensures the logo links to and loads from the hosted site and removes an unnecessary local header include.

Issue: #246

Version: #265