### PR TITLE
Update vignettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ For even more examples, vignettes, and the full function reference, visit the **
 
 Using `facet_wrap(~ group)`, this chart breaks down the daily commute mix across major US cities. Each panel shows one city's full distribution of transportation modes — car, bus, train, bicycle, motorcycle, walking, and ride-share — with each icon representing approximately 400 commuters. The dark background and per-mode color coding make it easy to compare cities at a glance.
 
-**[Code available in ggpop package website](https://jurjoroa.github.io/ggpop/)**.
+**[Code available in ggpop package website](https://jurjoroa.github.io/ggpop/articles/examples-geom-pop.html#facet_wrap-transportation-methods-across-us-cities)**.
 
 ![Example Plot facet](https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/transportation_methods_countries.png)
 
@@ -384,7 +384,7 @@ Using `facet_wrap(~ group)`, this chart breaks down the daily commute mix across
 
 Combining `geom_pop()` with the `geofacet` package places each state's panel in its actual geographic position on the US map. Here, skull icons represent gun deaths per 100,000 people (2023 CDC data), with each icon equal to 2,000 people. The layout immediately reveals regional patterns that a standard bar chart would hide — Mississippi sits at nearly 8× the rate of Massachusetts, and the South and rural West cluster visually as the hardest-hit regions.
 
-**[Code available in ggpop package website](https://jurjoroa.github.io/ggpop/)**.
+**[Code available in ggpop package website](https://jurjoroa.github.io/ggpop/articles/examples-geom-pop.html#facet_geo-gun-violence-across-us-states)**.
 
 ![Example Plot geofacet](https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/gun_death_rates_us_states_hexgrid.png)
 

--- a/vignettes/examples-geom-icon-point.Rmd
+++ b/vignettes/examples-geom-icon-point.Rmd
@@ -23,6 +23,7 @@ knitr::opts_chunk$set(
 library(ggpop)
 library(ggplot2)
 library(dplyr)
+library(ggtext)
 ```
 
 ```{r theme-setup, include = FALSE}
@@ -121,7 +122,7 @@ ggplot(df_food, aes(x = calories, y = protein, icon = icon, color = group)) +
   )
 ```
 
-```{r mapped-icons, echo = FALSE}
+```{r mapped-icons, echo = FALSE, message=FALSE, warning=FALSE}
 df_food <- data.frame(
   food     = c("Apple", "Carrot", "Orange", "Chicken", "Beef", "Salmon",
                "Milk", "Cheese", "Yogurt"),
@@ -136,12 +137,14 @@ df_food <- data.frame(
 df_food$group <- factor(df_food$group,
   levels = c("Fruit & Veg", "Dairy", "Meat & Fish"))
 
-ggplot(df_food, aes(x = calories, y = protein, icon = icon, color = group)) +
+ggplot(df_food, aes(x = calories, y = protein, icon = icon, color = food)) +
   geom_icon_point(size = 2, dpi = 100) +
   scale_color_manual(values = c(
-    "Fruit & Veg"  = "#43A047",
+    "Apple" = "#43A047", "Carrot" = "#43A047", "Orange" = "#43A047",
     "Dairy"        = "#1E88E5",
-    "Meat & Fish"  = "#E53935"
+    "Milk" = "#1E88E5", "Cheese" = "#1E88E5", "Yogurt" = "#1E88E5",
+    "Meat & Fish"  = "#E53935",
+    "Chicken" = "#E53935", "Beef" = "#E53935", "Salmon" = "#E53935"
   )) +
   theme_pop() +
   theme_transp +
@@ -310,7 +313,215 @@ ggplot(df_health, aes(x = spend, y = life_exp,
 
 ---
 
-## Example 5: Combined Geoms
+## Example 5: Paris 2024 Olympics — New Sports
+
+`geom_icon_point()` in a fixed-position grid with no traditional axes. All 45 Olympic disciplines at Paris 2024 are arranged in a 9×5 layout, each with its own icon. The 4 sports making their Olympic debut are highlighted in cyan; all existing disciplines are in gold. Annotations use `ggtext` for inline HTML styling.
+
+```{r paris-display, eval = FALSE}
+df_paris_disciplines <- data.frame(
+  sport = c(
+    # Aquatics (5)
+    "Swimming", "Diving", "Water Polo", "Artistic Swim", "Open Water",
+    # Racket (3)
+    "Badminton", "Tennis", "Table Tennis",
+    # Court / team (6)
+    "Volleyball", "Beach Volley", "Basketball", "3x3 Basketball",
+    "Handball", "Hockey",
+    # Combat (5)
+    "Boxing", "Judo", "Taekwondo", "Wrestling", "Fencing",
+    # Athletics (5)
+    "Athletics", "Triathlon", "Pentathlon", "Rowing", "Sailing",
+    # Ball (3)
+    "Football", "Rugby", "Golf",
+    # Precision (2)
+    "Archery", "Shooting",
+    # Cycling (5)
+    "Road Cycling", "Track Cycling", "MTB", "BMX Racing", "BMX Freestyle",
+    # Other (5)
+    "Equestrian", "Gymnastics", "Rhythmic Gym", "Trampoline", "Weightlifting",
+    # Canoe (2)
+    "Canoe Sprint", "Canoe Slalom",
+    # New (4)
+    "Breaking", "Skateboarding", "Sport Climbing", "Surfing"
+  ),
+  icon = c(
+    "person-swimming", "water", "droplet", "star", "wave-square",
+    "table-tennis-paddle-ball", "baseball-bat-ball", "circle",
+    "volleyball", "umbrella-beach", "basketball", "people-group",
+    "hand-holding", "hockey-puck",
+    "hand-fist", "hands", "shoe-prints", "person", "shield",
+    "person-running", "person-biking", "list-check", "anchor", "sailboat",
+    "futbol", "football", "golf-ball-tee",
+    "bullseye", "gun",
+    "road", "bicycle", "tree", "flag-checkered", "infinity",
+    "horse", "child", "ribbon", "arrows-up-to-line", "dumbbell",
+    "water-ladder", "person-falling-burst",
+    "music", "person-skating", "mountain", "compass"
+  ),
+  is_new = c(rep(FALSE, 41), TRUE, TRUE, TRUE, TRUE)
+)
+
+stopifnot(nrow(df_paris_disciplines) == 45)
+stopifnot(!anyDuplicated(df_paris_disciplines$sport))
+stopifnot(!anyDuplicated(df_paris_disciplines$icon))
+
+bg <- "#01394f"
+
+df_grid <- expand.grid(x = 1:9, y = 5:1) %>%
+  arrange(y, x) %>%
+  mutate(
+    sport  = df_paris_disciplines$sport,
+    icon   = df_paris_disciplines$icon,
+    is_new = df_paris_disciplines$is_new,
+    color  = ifelse(is_new, "#4DEEEA", "#E8C84A")
+  )
+
+ggplot(df_grid, aes(x = x, y = y)) +
+  geom_icon_point(
+    aes(icon = icon, color = I(color)),
+    size = 1.55, dpi = 100) +
+  geom_text(
+    aes(y = y - 0.38, label = sport, color = I(color)),
+    size = 1.5, lineheight = 0.85, fontface = "bold"
+  ) +
+  annotate(
+    "richtext",
+    x = 5, y = 7.8,
+    label = "<span style='color:#4DEEEA; font-size:28pt'><b>4 NEW SPORTS</b></span><br>
+             <span style='color:#E8C84A; font-size:18pt'>JOIN THE PARIS 2024 OLYMPICS</span>",
+    fill = NA, label.size = 0, lineheight = 1.2
+  ) +
+  annotate(
+    "richtext",
+    x = 5, y = 6.75,
+    label = "<span style='color:#4DEEEA; font-size:9pt'><b>BREAKING &nbsp;\u00b7&nbsp;
+             SKATEBOARDING &nbsp;\u00b7&nbsp; SPORT CLIMBING &nbsp;\u00b7&nbsp; SURFING</b></span>",
+    fill = NA, label.size = 0
+  ) +
+  annotate("point", x = 2.6, y = -0.55, color = "#E8C84A", size = 3.5) +
+  annotate("text",  x = 3.0, y = -0.55,
+           label = "Existing discipline (41)", color = "#E8C84A",
+           size = 3.0, hjust = 0, fontface = "bold") +
+  annotate("point", x = 6.2, y = -0.55, color = "#4DEEEA", size = 3.5) +
+  annotate("text",  x = 6.6, y = -0.55,
+           label = "New sport (4)", color = "#4DEEEA",
+           size = 3.0, hjust = 0, fontface = "bold") +
+  annotate(
+    "richtext",
+    x = 5, y = -1.15,
+    label = "<span style='color:#E8C84A'>Source: IOC / Paris 2024 &nbsp;\u00b7&nbsp;
+             Original concept: <span style='color:#4DEEEA'>G. Karamanis</span>
+             &nbsp; github.com/gkaramanis/30DayChartChallenge &nbsp;\u00b7&nbsp;
+             Remake: ggpop</span>",
+    fill = NA, label.size = 0, size = 2.5, lineheight = 1.2
+  ) +
+  coord_fixed(clip = "off", xlim = c(0.5, 9.5), ylim = c(-1.6, 9.2)) +
+  theme_void() +
+  theme(
+    plot.background = element_rect(fill = bg, color = NA),
+    plot.margin     = margin(30, 40, 60, 40)
+  )
+```
+
+```{r paris, echo = FALSE, fig.width = 7, fig.height = 9}
+df_paris_disciplines <- data.frame(
+  sport = c(
+    "Swimming", "Diving", "Water Polo", "Artistic Swim", "Open Water",
+    "Badminton", "Tennis", "Table Tennis",
+    "Volleyball", "Beach Volley", "Basketball", "3x3 Basketball",
+    "Handball", "Hockey",
+    "Boxing", "Judo", "Taekwondo", "Wrestling", "Fencing",
+    "Athletics", "Triathlon", "Pentathlon", "Rowing", "Sailing",
+    "Football", "Rugby", "Golf",
+    "Archery", "Shooting",
+    "Road Cycling", "Track Cycling", "MTB", "BMX Racing", "BMX Freestyle",
+    "Equestrian", "Gymnastics", "Rhythmic Gym", "Trampoline", "Weightlifting",
+    "Canoe Sprint", "Canoe Slalom",
+    "Breaking", "Skateboarding", "Sport Climbing", "Surfing"
+  ),
+  icon = c(
+    "person-swimming", "water", "droplet", "star", "wave-square",
+    "table-tennis-paddle-ball", "baseball-bat-ball", "circle",
+    "volleyball", "umbrella-beach", "basketball", "people-group",
+    "hand-holding", "hockey-puck",
+    "hand-fist", "hands", "shoe-prints", "person", "shield",
+    "person-running", "person-biking", "list-check", "anchor", "sailboat",
+    "futbol", "football", "golf-ball-tee",
+    "bullseye", "gun",
+    "road", "bicycle", "tree", "flag-checkered", "infinity",
+    "horse", "child", "ribbon", "arrows-up-to-line", "dumbbell",
+    "water-ladder", "person-falling-burst",
+    "music", "person-skating", "mountain", "compass"
+  ),
+  is_new = c(rep(FALSE, 41), TRUE, TRUE, TRUE, TRUE)
+)
+
+stopifnot(nrow(df_paris_disciplines) == 45)
+stopifnot(!anyDuplicated(df_paris_disciplines$sport))
+stopifnot(!anyDuplicated(df_paris_disciplines$icon))
+
+bg <- "#01394f"
+
+df_grid <- expand.grid(x = 1:9, y = 5:1) %>%
+  arrange(y, x) %>%
+  mutate(
+    sport  = df_paris_disciplines$sport,
+    icon   = df_paris_disciplines$icon,
+    is_new = df_paris_disciplines$is_new,
+    color  = ifelse(is_new, "#4DEEEA", "#E8C84A")
+  )
+
+ggplot(df_grid, aes(x = x, y = y)) +
+  geom_icon_point(
+    aes(icon = icon, color = I(color)),
+    size = 1.55, dpi = 100
+  ) +
+  geom_text(
+    aes(y = y - 0.38, label = sport, color = I(color)),
+    size = 1.5, lineheight = 0.85, fontface = "bold"
+  ) +
+  annotate(
+    "richtext",
+    x = 5, y = 7.8,
+    label = "<span style='color:#4DEEEA; font-size:28pt'><b>4 NEW SPORTS</b></span><br>
+             <span style='color:#E8C84A; font-size:18pt'>JOIN THE PARIS 2024 OLYMPICS</span>",
+    fill = NA, label.size = 0, lineheight = 1.2
+  ) +
+  annotate(
+    "richtext",
+    x = 5, y = 6.75,
+    label = "<span style='color:#4DEEEA; font-size:9pt'><b>BREAKING &nbsp;\u00b7&nbsp;
+             SKATEBOARDING &nbsp;\u00b7&nbsp; SPORT CLIMBING &nbsp;\u00b7&nbsp; SURFING</b></span>",
+    fill = NA, label.size = 0
+  ) +
+  annotate("point", x = 2.6, y = -0.55, color = "#E8C84A", size = 3.5) +
+  annotate("text",  x = 3.0, y = -0.55,
+           label = "Existing discipline (41)", color = "#E8C84A",
+           size = 3.0, hjust = 0, fontface = "bold") +
+  annotate("point", x = 6.2, y = -0.55, color = "#4DEEEA", size = 3.5) +
+  annotate("text",  x = 6.6, y = -0.55,
+           label = "New sport (4)", color = "#4DEEEA",
+           size = 3.0, hjust = 0, fontface = "bold") +
+  annotate(
+    "richtext",
+    x = 5, y = -1.15,
+    label = "<span style='color:#E8C84A'>Source: IOC / Paris 2024 &nbsp;\u00b7&nbsp;
+             Original concept: <span style='color:#4DEEEA'>G. Karamanis</span>
+             &nbsp; github.com/gkaramanis/30DayChartChallenge &nbsp;\u00b7&nbsp;
+             Remake: ggpop</span>",
+    fill = NA, label.size = 0, size = 2.5, lineheight = 1.2
+  ) +
+  coord_fixed(clip = "off", xlim = c(0.5, 9.5), ylim = c(-1.6, 9.2)) +
+  theme_void() +
+  theme(
+    plot.background = element_rect(fill = bg, color = NA),
+    plot.margin     = margin(30, 40, 60, 40)
+  )
+```
+
+---
+
+## Example 6: Combined Geoms
 
 `geom_icon_point()` works alongside any ggplot2 geom. Here combined with `geom_smooth()`, reference lines, labels, and quadrant annotations.
 
@@ -357,7 +568,7 @@ ggplot(df_health, aes(x = spend, y = life_exp,
 
 ---
 
-## Example 6: Dark Theme Scatter
+## Example 7: Dark Theme Scatter
 
 `geom_icon_point()` with `theme_pop_dark()` for a presentation-ready chart.
 
@@ -397,3 +608,11 @@ ggplot(df_academic, aes(x = study_hours, y = score,
     color    = "Role"
   )
 ```
+
+
+
+---
+
+## Example 8: Dark Theme Scatter
+
+

--- a/vignettes/examples-geom-pop.Rmd
+++ b/vignettes/examples-geom-pop.Rmd
@@ -489,3 +489,814 @@ ggplot() +
     color    = "Group"
   )
 ```
+
+
+
+
+## `facet_wrap()` — Transportation Methods Across US Cities
+
+Using `facet_wrap(~ group)`, this chart breaks down the daily commute mix across major US cities. Each panel shows one city's full distribution of transportation modes — car, bus, train, bicycle, motorcycle, walking, and ride-share — with each icon representing approximately 400 commuters. The dark background and per-mode color coding make it easy to compare cities at a glance.
+
+```{r transportation, eval = FALSE}
+
+# Example: Transportation Methods Across Cities with 7 Icon Groups
+library(ggplot2)
+library(dplyr)
+
+# 1. Create sample data for transportation methods across different countries
+df_transport <- data.frame(
+  country = rep(c("🇺🇸 United States", "🇩🇪 Germany", "🇳🇱 Netherlands", 
+                  "🇯🇵 Japan", "🇲🇽 Mexico"), each = 7),
+  method  = rep(c("car", "bus", "train", "bicycle", 
+                  "motorcycle", "walking", "taxi"), 5),
+            # United States (car-dominant, low walking)
+  value = c(70000, 15000, 12000,  6000,  8000,  5000,  9000,
+            # Germany (balanced multimodal)
+            35000, 20000, 25000, 15000,  4000, 22000,  4000,
+            # Netherlands (bike + walking high)
+            20000, 12000, 18000, 35000,  3000, 25000,  2000,
+            # Japan (transit + walking high)
+            15000, 18000, 40000,  5000,  2000, 30000,  3000,
+            # Mexico (walking high; mixed modes)
+            30000, 20000, 18000,  4000,  5000, 35000,  3000))
+
+# 2. Process the data for each country
+df_transport_prop <- process_data(
+  data          = df_transport,
+  group_var     = method,
+  sum_var       = value,
+  sample_size   = 150,
+  high_group_var = "country"
+)
+
+# 3. Assign Font Awesome icons to transportation methods
+df_transport_prop <- df_transport_prop %>%
+  mutate(icon = case_when(
+    type == "car"        ~ "car",
+    type == "bus"        ~ "bus",
+    type == "train"      ~ "train",
+    type == "bicycle"    ~ "bicycle",
+    type == "motorcycle" ~ "motorcycle",
+    type == "walking"    ~ "person-walking",
+    type == "taxi"       ~ "taxi"
+  ))
+
+library(showtext)
+library(sysfonts)
+
+sysfonts::font_add_google("Inter", "inter")
+
+
+showtext::showtext_auto()
+
+
+font_add_google("Inter", "inter")
+
+showtext::showtext_auto(FALSE)
+
+# 4. Plot with facet_wrap + legend placed inside bottom-right
+ggplot(data = df_transport_prop,
+    aes(icon = icon, group = type, color = type)) +
+  geom_pop(size = 1.5, arrange = TRUE) +
+  facet_wrap(~ group, ncol = 2) +
+  theme_void(base_size = 26) +
+  labs(title    = "Primary Transportation Methods Across Countries",
+       subtitle = "\nDistribution of daily commuters by transportation type",
+       caption = paste(
+      strwrap(
+        "Each panel displays a proportional sample (150 icons). 
+        Each icon represents roughly 750–840 commuters, varying by country.",
+        width = 35), collapse = "\n")) +
+  theme(
+    text = element_text(family = "inter"),
+    # Put legend INSIDE plot area (bottom-right)
+    legend.position = c(0.9, 0.05),
+    legend.justification = c(1, 0),
+    legend.direction = "horizontal",
+    legend.box = "horizontal",
+    strip.text = element_text(size = 30, color = "#D4AF38"),
+    legend.text = element_text(color = "#D4AF38", size = 15),
+    
+    plot.title    = element_text(hjust = 0.5, face = "bold", color = "#D4AF38"),
+    plot.subtitle = element_text(hjust = 0.5, color = "#D4AF38", size = 18,
+                                 margin = margin(b = 50)),
+    plot.caption = element_text(
+      hjust = .85, # Centers the caption horizontally
+      vjust = 10,   # Aligns the caption to the top of its available vertical space
+      size = 18,
+      color = "#D4AF38"
+    ),    
+    legend.title = element_text(
+      color = "#D4AF38",
+      size  = 18,
+      face  = "bold",
+      margin = margin(b = 10)  # pushes title downward
+    ),
+    legend.box.spacing = unit(4, "pt")  # pulls title under icons
+  ) +
+  scale_color_manual(
+    name = "Transportation mode",
+    values = c(
+      "car"        = "#E53935",
+      "bus"        = "#FB8C00",
+      "train"      = "#43A047",
+      "bicycle"    = "#00ACC1",
+      "motorcycle" = "#8E24AA",
+      "walking"    = "#FDD835",
+      "taxi"       = "#FFB300"
+    ),
+    labels = c(
+      "car"        = "Car",
+      "bus"        = "Bus",
+      "train"      = "Train/Subway",
+      "bicycle"    = "Bicycle",
+      "motorcycle" = "Motorcycle",
+      "walking"    = "Walking",
+      "taxi"       = "Taxi/Ride-share")) +
+  guides(
+    color = guide_legend(
+      ncol = 2,
+      byrow = TRUE,
+      title.position = "top",   # required internally
+      title.hjust = 0.5)) +
+  scale_legend_icon(size = 10)
+
+```
+
+
+```{r transportation_play, echo = FALSE, fig.width = 15, fig.height = 25, message=FALSE, warning=FALSE}
+# Example: Transportation Methods Across Cities with 7 Icon Groups
+library(ggplot2)
+library(dplyr)
+
+# 1. Create sample data for transportation methods across different countries
+df_transport <- data.frame(
+  country = rep(c("🇺🇸 United States", "🇩🇪 Germany", "🇳🇱 Netherlands", "🇯🇵 Japan", "🇲🇽 Mexico"), each = 7),
+  method  = rep(c("car", "bus", "train", "bicycle", "motorcycle", "walking", "taxi"), 5),
+  value = c(
+    # United States (car-dominant, low walking)
+    70000, 15000, 12000,  6000,  8000,  5000,  9000,
+    # Germany (balanced multimodal)
+    35000, 20000, 25000, 15000,  4000, 22000,  4000,
+    # Netherlands (bike + walking high)
+    20000, 12000, 18000, 35000,  3000, 25000,  2000,
+    # Japan (transit + walking high)
+    15000, 18000, 40000,  5000,  2000, 30000,  3000,
+    # Mexico (walking high; mixed modes)
+    30000, 20000, 18000,  4000,  5000, 35000,  3000
+  )
+)
+
+# 2. Process the data for each country
+df_transport_prop <- process_data(
+  data          = df_transport,
+  group_var     = method,
+  sum_var       = value,
+  sample_size   = 150,
+  high_group_var = "country"
+)
+
+# 3. Assign Font Awesome icons to transportation methods
+df_transport_prop <- df_transport_prop %>%
+  mutate(icon = case_when(
+    type == "car"        ~ "car",
+    type == "bus"        ~ "bus",
+    type == "train"      ~ "train",
+    type == "bicycle"    ~ "bicycle",
+    type == "motorcycle" ~ "motorcycle",
+    type == "walking"    ~ "person-walking",
+    type == "taxi"       ~ "taxi"
+  ))
+
+library(showtext)
+library(sysfonts)
+
+sysfonts::font_add_google("Inter", "inter")
+
+
+showtext::showtext_auto()
+
+
+font_add_google("Inter", "inter")
+
+showtext::showtext_auto(FALSE)
+
+# 4. Plot with facet_wrap + legend placed inside bottom-right (the “empty panel” area)
+ggplot() +
+  geom_pop(
+    data = df_transport_prop,
+    aes(icon = icon, group = type, color = type),
+    size = 1.5,
+    arrange = TRUE
+  ) +
+  facet_wrap(~ group, ncol = 2) +
+  theme_void(base_size = 26) +
+  labs(
+    title    = "Primary Transportation Methods Across Countries",
+    subtitle = "\nDistribution of daily commuters by transportation type",
+    caption = paste(
+      strwrap(
+        "Each panel displays a proportional sample (150 icons). Each icon represents roughly 750–840 commuters, varying by country.",
+        width = 35
+      ),
+      collapse = "\n"
+    )
+  ) +
+  theme(
+    text = element_text(family = "inter"),
+    # Put legend INSIDE plot area (bottom-right)
+    legend.position = c(0.9, 0.05),
+    legend.justification = c(1, 0),
+    legend.direction = "horizontal",
+    legend.box = "horizontal",
+
+    plot.background  = element_blank(),
+    panel.background = element_blank(),
+    
+    strip.text = element_text(size = 30, color = "#D4AF38"),
+    
+    legend.background = element_blank(),
+    legend.text = element_text(color = "#D4AF38", size = 15),
+    
+    plot.title    = element_text(hjust = 0.5, face = "bold", color = "#D4AF38"),
+    plot.subtitle = element_text(hjust = 0.5, color = "#D4AF38", size = 18,
+                                 margin = margin(b = 50)),
+    plot.caption = element_text(
+      hjust = .85, # Centers the caption horizontally
+      vjust = 10,   # Aligns the caption to the top of its available vertical space
+      size = 18,
+      color = "#D4AF38"
+    ),    
+    legend.title = element_text(
+      color = "#D4AF38",
+      size  = 18,
+      face  = "bold",
+      margin = margin(b = 10)  # pushes title downward
+    ),
+    legend.box.spacing = unit(4, "pt")  # pulls title under icons
+  ) +
+  scale_color_manual(
+    name = "Transportation mode",
+    values = c(
+      "car"        = "#E53935",
+      "bus"        = "#FB8C00",
+      "train"      = "#43A047",
+      "bicycle"    = "#00ACC1",
+      "motorcycle" = "#8E24AA",
+      "walking"    = "#FDD835",
+      "taxi"       = "#FFB300"
+    ),
+    labels = c(
+      "car"        = "Car",
+      "bus"        = "Bus",
+      "train"      = "Train/Subway",
+      "bicycle"    = "Bicycle",
+      "motorcycle" = "Motorcycle",
+      "walking"    = "Walking",
+      "taxi"       = "Taxi/Ride-share"
+    )
+  ) +
+  guides(
+    color = guide_legend(
+      ncol = 2,
+      byrow = TRUE,
+      title.position = "top",   # required internally
+      title.hjust = 0.5
+    )
+  ) +
+  scale_legend_icon(size = 10)
+
+```
+
+
+## `facet_geo()` — Gun Violence Across US States
+
+Combining `geom_pop()` with the `geofacet` package places each state's panel in its actual geographic position on the US map. Here, skull icons represent gun deaths per 100,000 people (2023 CDC data), with each icon equal to 2,000 people. The layout immediately reveals regional patterns that a standard bar chart would hide — Mississippi sits at nearly 8× the rate of Massachusetts, and the South and rural West cluster visually as the hardest-hit regions.
+
+
+
+```{r guns_plot, eval = FALSE, message=FALSE, warning=FALSE}
+
+
+library(sf)
+library(dplyr)
+library(geofacet)
+
+url <- "https://raw.githubusercontent.com/holtzy/D3-graph-gallery/7a5e5e1b1009312506ebd873d7858fa424c14b68/DATA/us_states_hexgrid.geojson.json"
+
+my_sf <- read_sf(url) %>%
+  mutate(
+    google_name = gsub(" \\(United States\\)", "", google_name)
+  )
+
+stopifnot("iso3166_2" %in% names(my_sf))
+
+states_in_hex <- my_sf %>%
+  st_drop_geometry() %>%
+  transmute(state = iso3166_2) %>%
+  distinct()
+# ---- Real state-level infant mortality rates ----
+# Data from CDC National Vital Statistics System, 2023
+# Infant deaths per 1,000 live births
+
+# ---- Real state-level gun death rates ----
+# Data from CDC/Violence Policy Center, 2023
+# Gun deaths per 100,000 population (all causes: homicide, suicide, unintentional)
+
+df_rates <- states_in_hex %>%
+  mutate(gun_death_rate_per_100k = case_when(
+    state == "AL" ~ 25.6,
+    state == "AK" ~ 23.5,
+    state == "AZ" ~ 18.5,
+    state == "AR" ~ 21.9,
+    state == "CA" ~ 8.0,
+    state == "CO" ~ 16.6,
+    state == "CT" ~ 6.2,
+    state == "DE" ~ 12.0,
+    state == "FL" ~ 13.7,
+    state == "GA" ~ 18.6,
+    state == "HI" ~ 4.9,
+    state == "ID" ~ 17.9,
+    state == "IL" ~ 13.5,
+    state == "IN" ~ 18.3,
+    state == "IA" ~ 10.5,
+    state == "KS" ~ 16.3,
+    state == "KY" ~ 18.4,
+    state == "LA" ~ 28.3,
+    state == "ME" ~ 14.0,
+    state == "MD" ~ 12.3,
+    state == "MA" ~ 3.7,  # Lowest
+    state == "MI" ~ 13.9,
+    state == "MN" ~ 8.9,
+    state == "MS" ~ 29.4,  # Highest
+    state == "MO" ~ 21.4,
+    state == "MT" ~ 21.5,
+    state == "NE" ~ 10.6,
+    state == "NV" ~ 18.4,
+    state == "NH" ~ 9.6,
+    state == "NJ" ~ 4.6,
+    state == "NM" ~ 25.3,
+    state == "NY" ~ 4.7,
+    state == "NC" ~ 16.4,
+    state == "ND" ~ 12.8,
+    state == "OH" ~ 15.0,
+    state == "OK" ~ 19.9,
+    state == "OR" ~ 14.2,
+    state == "PA" ~ 13.6,
+    state == "RI" ~ 4.8,
+    state == "SC" ~ 19.1,
+    state == "SD" ~ 12.3,
+    state == "TN" ~ 22.0,
+    state == "TX" ~ 14.9,
+    state == "UT" ~ 14.8,
+    state == "VT" ~ 12.0,
+    state == "VA" ~ 13.8,
+    state == "WA" ~ 13.0,
+    state == "WV" ~ 16.8,
+    state == "WI" ~ 12.7,
+    state == "WY" ~ 21.5,
+    state == "DC" ~ 28.5,  # DC has very high rate
+    TRUE ~ 13.7  # US average as fallback
+  )) %>%
+  # Convert rate per 100,000 to expected cases per 100 people
+  # Rate is per 100,000, so divide by 1,000 to get per 100
+  mutate(
+    cases_per_100 = round(gun_death_rate_per_100k / 1000, 1),
+    # Convert to probability for binomial sampling
+    gun_death_rate = gun_death_rate_per_100k / 100000
+  )
+# ---- Real state-level gun death rates ----
+# Data from CDC/Violence Policy Center, 2023
+# Gun deaths per 100,000 population (all causes: homicide, suicide, unintentional)
+# Each icon represents 1,000 people, so 100 icons = 100,000 people
+
+df_rates <- states_in_hex %>%
+  mutate(gun_death_rate_per_100k = case_when(
+    state == "AL" ~ 25.6,
+    state == "AK" ~ 23.5,
+    state == "AZ" ~ 18.5,
+    state == "AR" ~ 21.9,
+    state == "CA" ~ 8.0,
+    state == "CO" ~ 16.6,
+    state == "CT" ~ 6.2,
+    state == "DE" ~ 12.0,
+    state == "FL" ~ 13.7,
+    state == "GA" ~ 18.6,
+    state == "HI" ~ 4.9,
+    state == "ID" ~ 17.9,
+    state == "IL" ~ 13.5,
+    state == "IN" ~ 18.3,
+    state == "IA" ~ 10.5,
+    state == "KS" ~ 16.3,
+    state == "KY" ~ 18.4,
+    state == "LA" ~ 28.3,
+    state == "ME" ~ 14.0,
+    state == "MD" ~ 12.3,
+    state == "MA" ~ 3.7,  # Lowest
+    state == "MI" ~ 13.9,
+    state == "MN" ~ 8.9,
+    state == "MS" ~ 29.4,  # Highest
+    state == "MO" ~ 21.4,
+    state == "MT" ~ 21.5,
+    state == "NE" ~ 10.6,
+    state == "NV" ~ 18.4,
+    state == "NH" ~ 9.6,
+    state == "NJ" ~ 4.6,
+    state == "NM" ~ 25.3,
+    state == "NY" ~ 4.7,
+    state == "NC" ~ 16.4,
+    state == "ND" ~ 12.8,
+    state == "OH" ~ 15.0,
+    state == "OK" ~ 19.9,
+    state == "OR" ~ 14.2,
+    state == "PA" ~ 13.6,
+    state == "RI" ~ 4.8,
+    state == "SC" ~ 19.1,
+    state == "SD" ~ 12.3,
+    state == "TN" ~ 22.0,
+    state == "TX" ~ 14.9,
+    state == "UT" ~ 14.8,
+    state == "VT" ~ 12.0,
+    state == "VA" ~ 13.8,
+    state == "WA" ~ 13.0,
+    state == "WV" ~ 16.8,
+    state == "WI" ~ 12.7,
+    state == "WY" ~ 21.5,
+    state == "DC" ~ 28.5,
+    TRUE ~ 13.7  # US average as fallback
+  )) %>%
+  # Since each icon = 1,000 people and we have 100 icons (100,000 people)
+  # The rate per 100,000 is exactly the number of affected icons
+  mutate(
+    expected_deaths_per_100_icons = gun_death_rate_per_100k,
+    # Round to get whole number of deaths
+    deaths_count = round(gun_death_rate_per_100k)
+  )
+
+# ---- Create 100-icon samples per state ----
+# Each icon represents 1,000 people
+df_people <- df_rates %>%
+  group_by(state, deaths_count, gun_death_rate_per_100k) %>%
+  summarise(
+    # Create 100 icons: deaths_count will be "gun death", rest will be "survived"
+    icon_id = 1:100,
+    status = if_else(icon_id <= unique(deaths_count), "gun death", "no gun death"),
+    .groups = "drop"
+  )
+
+# ---- Convert to ggpop format ----
+df_hex_prop <- process_data(
+  data = df_people,
+  group_var = status,
+  sum_var = NULL,
+  sample_size = 50,
+  high_group_var = "state"
+)
+
+df_hex_prop <- df_hex_prop %>%
+  mutate(
+    icon = case_when(
+      type == "gun death" ~ "skull",
+      type == "no gun death" ~ "person",
+      TRUE ~ "person"
+    )
+  ) %>%
+  rename(code = group)
+# ---- Plot using facet_geo ----
+# ---- Plot using facet_geo with black background and enhanced design ----
+# ---- Plot using facet_geo with black background and enhanced design ----
+ggplot(df_hex_prop, aes(icon = icon, group = type, color = type)) +
+  geom_pop(size = 3.5, arrange = TRUE, facet = "code") +  # Increased size since fewer icons
+  geofacet::facet_geo(~ code, grid = "us_state_grid3", label = "name") +
+  scale_color_manual(
+    values = c("gun death" = "#FF1744", "no gun death" = "#42A5F5"),
+    labels = c("Gun death (each skull = 2,000 people)", "No gun death")
+  ) +
+  theme_void(base_size = 14) +
+  labs(
+    title = "GUN VIOLENCE ACROSS AMERICA",
+    subtitle = "Each icon represents 2,000 people • Skulls show gun deaths per 100,000 population\nMississippi has nearly 8× the gun death rate of Massachusetts",
+    caption = "Data: CDC/Violence Policy Center, 2023 (age-adjusted rates: homicide, suicide, accidents)\nHighest: Mississippi (29.4 per 100k = ~15 skulls) • Lowest: Massachusetts (3.7 per 100k = ~2 skulls) • National Average: 13.7 per 100k"
+  ) +
+  scale_legend_icon(size = 6) +
+  theme(
+    # Black background
+    plot.background = element_blank(),
+    panel.background = element_blank(),
+    
+    # Legend styling
+    legend.position = "bottom",
+    legend.title = element_blank(),
+    legend.text = element_text(color = "#D4AF37", size = 16, face = "bold"),
+    legend.background =  element_blank(),
+    legend.key = element_blank(),
+    legend.margin = margin(t = 15, b = 5),
+    
+    # State labels
+    strip.text = element_text(
+      size = 12, 
+      color = "#D4AF37",
+      margin = margin(b = 4)
+    ),
+    
+    # Title styling
+    plot.title = element_text(
+      hjust = 0.5, 
+      face = "bold", 
+      size = 24, 
+      color = "#FF1744",
+      margin = margin(b = 10),
+      family = "sans"
+    ),
+    
+    # Subtitle styling
+    plot.subtitle = element_text(
+      hjust = 0.5, 
+      size = 13, 
+      lineheight = 1.3,
+      color = "#D4AF37",
+      margin = margin(b = 15)
+    ),
+    
+    # Caption styling
+    plot.caption = element_text(
+      hjust = 0.5, 
+      size = 9.5, 
+      color = "#D4AF37", 
+      lineheight = 1.4,
+      margin = margin(t = 15)
+    ),
+    plot.margin = margin(t = 40, r = 40, b = 40, l = 40)
+    
+    # Overall plot margins
+    
+  )
+
+```
+
+
+```{r guns, echo = FALSE, fig.width = 15, fig.height = 15, message=FALSE, warning=FALSE}
+
+
+library(sf)
+library(dplyr)
+library(geofacet)
+
+url <- "https://raw.githubusercontent.com/holtzy/D3-graph-gallery/7a5e5e1b1009312506ebd873d7858fa424c14b68/DATA/us_states_hexgrid.geojson.json"
+
+my_sf <- read_sf(url) %>%
+  mutate(
+    google_name = gsub(" \\(United States\\)", "", google_name)
+  )
+
+stopifnot("iso3166_2" %in% names(my_sf))
+
+states_in_hex <- my_sf %>%
+  st_drop_geometry() %>%
+  transmute(state = iso3166_2) %>%
+  distinct()
+# ---- Real state-level infant mortality rates ----
+# Data from CDC National Vital Statistics System, 2023
+# Infant deaths per 1,000 live births
+
+# ---- Real state-level gun death rates ----
+# Data from CDC/Violence Policy Center, 2023
+# Gun deaths per 100,000 population (all causes: homicide, suicide, unintentional)
+
+df_rates <- states_in_hex %>%
+  mutate(gun_death_rate_per_100k = case_when(
+    state == "AL" ~ 25.6,
+    state == "AK" ~ 23.5,
+    state == "AZ" ~ 18.5,
+    state == "AR" ~ 21.9,
+    state == "CA" ~ 8.0,
+    state == "CO" ~ 16.6,
+    state == "CT" ~ 6.2,
+    state == "DE" ~ 12.0,
+    state == "FL" ~ 13.7,
+    state == "GA" ~ 18.6,
+    state == "HI" ~ 4.9,
+    state == "ID" ~ 17.9,
+    state == "IL" ~ 13.5,
+    state == "IN" ~ 18.3,
+    state == "IA" ~ 10.5,
+    state == "KS" ~ 16.3,
+    state == "KY" ~ 18.4,
+    state == "LA" ~ 28.3,
+    state == "ME" ~ 14.0,
+    state == "MD" ~ 12.3,
+    state == "MA" ~ 3.7,  # Lowest
+    state == "MI" ~ 13.9,
+    state == "MN" ~ 8.9,
+    state == "MS" ~ 29.4,  # Highest
+    state == "MO" ~ 21.4,
+    state == "MT" ~ 21.5,
+    state == "NE" ~ 10.6,
+    state == "NV" ~ 18.4,
+    state == "NH" ~ 9.6,
+    state == "NJ" ~ 4.6,
+    state == "NM" ~ 25.3,
+    state == "NY" ~ 4.7,
+    state == "NC" ~ 16.4,
+    state == "ND" ~ 12.8,
+    state == "OH" ~ 15.0,
+    state == "OK" ~ 19.9,
+    state == "OR" ~ 14.2,
+    state == "PA" ~ 13.6,
+    state == "RI" ~ 4.8,
+    state == "SC" ~ 19.1,
+    state == "SD" ~ 12.3,
+    state == "TN" ~ 22.0,
+    state == "TX" ~ 14.9,
+    state == "UT" ~ 14.8,
+    state == "VT" ~ 12.0,
+    state == "VA" ~ 13.8,
+    state == "WA" ~ 13.0,
+    state == "WV" ~ 16.8,
+    state == "WI" ~ 12.7,
+    state == "WY" ~ 21.5,
+    state == "DC" ~ 28.5,  # DC has very high rate
+    TRUE ~ 13.7  # US average as fallback
+  )) %>%
+  # Convert rate per 100,000 to expected cases per 100 people
+  # Rate is per 100,000, so divide by 1,000 to get per 100
+  mutate(
+    cases_per_100 = round(gun_death_rate_per_100k / 1000, 1),
+    # Convert to probability for binomial sampling
+    gun_death_rate = gun_death_rate_per_100k / 100000
+  )
+# ---- Real state-level gun death rates ----
+# Data from CDC/Violence Policy Center, 2023
+# Gun deaths per 100,000 population (all causes: homicide, suicide, unintentional)
+# Each icon represents 1,000 people, so 100 icons = 100,000 people
+
+df_rates <- states_in_hex %>%
+  mutate(gun_death_rate_per_100k = case_when(
+    state == "AL" ~ 25.6,
+    state == "AK" ~ 23.5,
+    state == "AZ" ~ 18.5,
+    state == "AR" ~ 21.9,
+    state == "CA" ~ 8.0,
+    state == "CO" ~ 16.6,
+    state == "CT" ~ 6.2,
+    state == "DE" ~ 12.0,
+    state == "FL" ~ 13.7,
+    state == "GA" ~ 18.6,
+    state == "HI" ~ 4.9,
+    state == "ID" ~ 17.9,
+    state == "IL" ~ 13.5,
+    state == "IN" ~ 18.3,
+    state == "IA" ~ 10.5,
+    state == "KS" ~ 16.3,
+    state == "KY" ~ 18.4,
+    state == "LA" ~ 28.3,
+    state == "ME" ~ 14.0,
+    state == "MD" ~ 12.3,
+    state == "MA" ~ 3.7,  # Lowest
+    state == "MI" ~ 13.9,
+    state == "MN" ~ 8.9,
+    state == "MS" ~ 29.4,  # Highest
+    state == "MO" ~ 21.4,
+    state == "MT" ~ 21.5,
+    state == "NE" ~ 10.6,
+    state == "NV" ~ 18.4,
+    state == "NH" ~ 9.6,
+    state == "NJ" ~ 4.6,
+    state == "NM" ~ 25.3,
+    state == "NY" ~ 4.7,
+    state == "NC" ~ 16.4,
+    state == "ND" ~ 12.8,
+    state == "OH" ~ 15.0,
+    state == "OK" ~ 19.9,
+    state == "OR" ~ 14.2,
+    state == "PA" ~ 13.6,
+    state == "RI" ~ 4.8,
+    state == "SC" ~ 19.1,
+    state == "SD" ~ 12.3,
+    state == "TN" ~ 22.0,
+    state == "TX" ~ 14.9,
+    state == "UT" ~ 14.8,
+    state == "VT" ~ 12.0,
+    state == "VA" ~ 13.8,
+    state == "WA" ~ 13.0,
+    state == "WV" ~ 16.8,
+    state == "WI" ~ 12.7,
+    state == "WY" ~ 21.5,
+    state == "DC" ~ 28.5,
+    TRUE ~ 13.7  # US average as fallback
+  )) %>%
+  # Since each icon = 1,000 people and we have 100 icons (100,000 people)
+  # The rate per 100,000 is exactly the number of affected icons
+  mutate(
+    expected_deaths_per_100_icons = gun_death_rate_per_100k,
+    # Round to get whole number of deaths
+    deaths_count = round(gun_death_rate_per_100k)
+  )
+
+# ---- Create 100-icon samples per state ----
+# Each icon represents 1,000 people
+df_people <- df_rates %>%
+  group_by(state, deaths_count, gun_death_rate_per_100k) %>%
+  summarise(
+    # Create 100 icons: deaths_count will be "gun death", rest will be "survived"
+    icon_id = 1:100,
+    status = if_else(icon_id <= unique(deaths_count), "gun death", "no gun death"),
+    .groups = "drop"
+  )
+
+# ---- Convert to ggpop format ----
+df_hex_prop <- process_data(
+  data = df_people,
+  group_var = status,
+  sum_var = NULL,
+  sample_size = 50,
+  high_group_var = "state"
+)
+
+df_hex_prop <- df_hex_prop %>%
+  mutate(
+    icon = case_when(
+      type == "gun death" ~ "skull",
+      type == "no gun death" ~ "person",
+      TRUE ~ "person"
+    )
+  ) %>%
+  rename(code = group)
+# ---- Plot using facet_geo ----
+# ---- Plot using facet_geo with black background and enhanced design ----
+# ---- Plot using facet_geo with black background and enhanced design ----
+ggplot(df_hex_prop, aes(icon = icon, group = type, color = type)) +
+  geom_pop(size = 3.5, arrange = TRUE, facet = "code") +  # Increased size since fewer icons
+  geofacet::facet_geo(~ code, grid = "us_state_grid3", label = "name") +
+  scale_color_manual(
+    values = c("gun death" = "#FF1744", "no gun death" = "#42A5F5"),
+    labels = c("Gun death (each skull = 2,000 people)", "No gun death")
+  ) +
+  theme_void(base_size = 14) +
+  labs(
+    title = "GUN VIOLENCE ACROSS AMERICA",
+    subtitle = "Each icon represents 2,000 people • Skulls show gun deaths per 100,000 population\nMississippi has nearly 8× the gun death rate of Massachusetts",
+    caption = "Data: CDC/Violence Policy Center, 2023 (age-adjusted rates: homicide, suicide, accidents)\nHighest: Mississippi (29.4 per 100k = ~15 skulls) • Lowest: Massachusetts (3.7 per 100k = ~2 skulls) • National Average: 13.7 per 100k"
+  ) +
+  scale_legend_icon(size = 6) +
+  theme(
+    # Black background
+    plot.background = element_blank(),
+    panel.background = element_blank(),
+    
+    # Legend styling
+    legend.position = "bottom",
+    legend.title = element_blank(),
+    legend.text = element_text(color = "#D4AF37", size = 16, face = "bold"),
+    legend.background =  element_blank(),
+    legend.key = element_blank(),
+    legend.margin = margin(t = 15, b = 5),
+    
+    # State labels
+    strip.text = element_text(
+      size = 12, 
+      color = "#D4AF37",
+      margin = margin(b = 4)
+    ),
+    
+    # Title styling
+    plot.title = element_text(
+      hjust = 0.5, 
+      face = "bold", 
+      size = 24, 
+      color = "#FF1744",
+      margin = margin(b = 10),
+      family = "sans"
+    ),
+    
+    # Subtitle styling
+    plot.subtitle = element_text(
+      hjust = 0.5, 
+      size = 13, 
+      lineheight = 1.3,
+      color = "#D4AF37",
+      margin = margin(b = 15)
+    ),
+    
+    # Caption styling
+    plot.caption = element_text(
+      hjust = 0.5, 
+      size = 9.5, 
+      color = "#D4AF37", 
+      lineheight = 1.4,
+      margin = margin(t = 15)
+    ),
+    plot.margin = margin(t = 40, r = 40, b = 40, l = 40)
+    
+    # Overall plot margins
+    
+  )
+
+```
+
+
+
+
+
+
+


### PR DESCRIPTION
This pull request enhances the `ggpop` documentation and vignettes with improved examples, a new Olympics visualization, and several usability and clarity updates. The most significant changes include the addition of a detailed Paris 2024 Olympics icon-grid example, improved color mapping in the food icons example, and updated links in the `README.md` for direct access to specific example sections.

**New Olympics Visualization Example:**

* Added a comprehensive Paris 2024 Olympics example to `vignettes/examples-geom-icon-point.Rmd`, showcasing all 45 disciplines in a 9×5 grid using `geom_icon_point()`, with new sports highlighted and rich text annotations for context and accessibility.

**Improvements to Existing Examples:**

* Changed the color mapping in the food icons example to map colors by individual food items instead of by group, and updated the color scale accordingly for better visual distinction.
* Updated the chunk options for the mapped-icons example to suppress messages and warnings for cleaner output.

**Documentation and Theming Updates:**

* Added `ggtext` to the list of libraries loaded in the vignette to support rich text annotations in plots.
* Shifted the numbering and titles of subsequent examples to accommodate the new Olympics example, ensuring logical flow and clarity in the vignette. [[1]](diffhunk://#diff-649675cfb8ff576751b092f48bb5dc57772918e0f30be1a8a92dc09475cb7aa0L360-R571) [[2]](diffhunk://#diff-649675cfb8ff576751b092f48bb5dc57772918e0f30be1a8a92dc09475cb7aa0R611-R618)

**README Improvements:**

* Updated example links in `README.md` to point directly to the relevant sections of the online documentation for easier navigation.
*
Issue: https://github.com/jurjoroa/ggpop/issues/246

Version: https://github.com/jurjoroa/ggpop/issues/265