### PR TITLE
Install sf system deps in CI and update DESCRIPTION

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -42,6 +42,10 @@ jobs:
         with:
           use-public-rspm: true
 
+      - name: Install system dependencies for sf
+        if: runner.os == 'Linux'
+        run: sudo apt-get update -y && sudo apt-get install -y libgdal-dev libproj-dev libgeos-dev libudunits2-dev
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown, local::.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Suggests:
     testthat (>= 3.0.0),
     knitr,
     rmarkdown
+Config/Needs/website: sf, geofacet, ggtext
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Depends:


### PR DESCRIPTION
Add Linux system packages (libgdal-dev, libproj-dev, libgeos-dev, libudunits2-dev) to the pkgdown GitHub Actions workflow so sf can build on CI. Also add Config/Needs/website: sf, geofacet, ggtext to DESCRIPTION to declare website vignette/rendering dependencies.

Issue: #246

Version: #265