### PR TITLE
Add cowplot to Suggests and guard vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,8 @@ RoxygenNote: 7.3.3
 Suggests:
     testthat (>= 3.0.0),
     knitr,
-    rmarkdown
+    rmarkdown,
+    cowplot
 Config/Needs/website: sf, geofacet, ggtext, quarto
 VignetteBuilder: knitr
 Config/testthat/edition: 3

--- a/vignettes/examples-geom-pop.qmd
+++ b/vignettes/examples-geom-pop.qmd
@@ -641,6 +641,8 @@ Combining multiple `geom_pop()` panels into a single plot with the `cowplot` pac
 ```{r}
 #| label: cowplot-display
 #| eval: false
+#| eval: !expr requireNamespace("cowplot", quietly = TRUE)
+
 
 library(ggpop)
 library(ggplot2)
@@ -761,6 +763,7 @@ top_row    <- plot_grid(p1, p2, ncol = 2)
 bottom_row <- plot_grid(NULL, p3, NULL, ncol = 3, rel_widths = c(0.5, 1, 0.5))
 plot_grid(top_row, bottom_row, nrow = 2)
 ```
+
 
 ```{r}
 #| label: cowplot


### PR DESCRIPTION
Add cowplot to DESCRIPTION Suggests and update the examples-geom-pop.qmd vignette to conditionally evaluate the cowplot display chunk only when the cowplot namespace is available (requireNamespace). Includes a minor whitespace tweak in the vignette.

Issue: #246

Version: #265