### PR TITLE
Fix bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,8 @@ RoxygenNote: 7.3.3
 Suggests:
     testthat (>= 3.0.0),
     knitr,
-    rmarkdown
+    rmarkdown,
+    cowplot
 Config/Needs/website: sf, geofacet, ggtext, quarto
 VignetteBuilder: knitr
 Config/testthat/edition: 3

--- a/vignettes/examples-geom-pop.qmd
+++ b/vignettes/examples-geom-pop.qmd
@@ -641,6 +641,8 @@ Combining multiple `geom_pop()` panels into a single plot with the `cowplot` pac
 ```{r}
 #| label: cowplot-display
 #| eval: false
+#| eval: !expr requireNamespace("cowplot", quietly = TRUE)
+
 
 library(ggpop)
 library(ggplot2)
@@ -761,6 +763,7 @@ top_row    <- plot_grid(p1, p2, ncol = 2)
 bottom_row <- plot_grid(NULL, p3, NULL, ncol = 3, rel_widths = c(0.5, 1, 0.5))
 plot_grid(top_row, bottom_row, nrow = 2)
 ```
+
 
 ```{r}
 #| label: cowplot


### PR DESCRIPTION
This pull request introduces support for the `cowplot` package to enhance the visualization capabilities of the project, particularly for combining multiple `geom_pop()` panels into a single plot. The changes ensure that `cowplot` is suggested as a dependency and that its usage in vignettes is conditional on its availability.

Dependency management:

* Added `cowplot` to the `Suggests` field in the `DESCRIPTION` file to formally recommend it as an optional package.

Vignette improvements:

* Updated the code chunk in `vignettes/examples-geom-pop.qmd` to conditionally evaluate based on the presence of the `cowplot` package, improving robustness for users without `cowplot` installed.
* Added a new code chunk for `cowplot` at the end of `vignettes/examples-geom-pop.qmd` for demonstration purposes.

Issue: [#246](https://github.com/jurjoroa/ggpop/issues/246)

Version: [#265](https://github.com/jurjoroa/ggpop/issues/265)