### PR TITLE
Expose geom_pop coordinates for downstream layers

### DIFF
--- a/R/geom_pop.R
+++ b/R/geom_pop.R
@@ -274,7 +274,8 @@ geom_pop <- function(mapping = NULL, data = NULL, stat = "identity",
   layer_out$params$.ggpop_facet <- if (.facet_explicit) facet_col else NULL
 
   structure(
-    list(layer = layer_out, facet_col = if (.facet_explicit) facet_col else NULL),
+    list(layer = layer_out, facet_col = if (.facet_explicit) facet_col else NULL,
+         df_pop = df_final),
     class = "ggpop_geom_pop"
   )
 }

--- a/R/scale_legend_icon.R
+++ b/R/scale_legend_icon.R
@@ -74,6 +74,16 @@ ggplot_add.ggpop_geom_pop <- function(object, plot, object_name, ...) {
   # add the layer
   plot <- plot + object$layer
 
+  # Expose geom_pop's internally computed coordinates (x1, y1) so that
+  # downstream layers (geom_text, geom_label, etc.) can inherit x and y
+  # without the user specifying them explicitly.
+  if (!is.null(object$df_pop)) {
+    plot$data <- object$df_pop
+    plot$mapping[["icon"]] <- NULL                        # consumed by geom_pop
+    if (!"x" %in% names(plot$mapping)) plot$mapping[["x"]] <- as.name("x1")
+    if (!"y" %in% names(plot$mapping)) plot$mapping[["y"]] <- as.name("y1")
+  }
+
   # If geom_pop had an explicit facet=, automatically add facet_wrap(~facet_col)
   if (!is.null(object$facet_col) && nzchar(object$facet_col)) {
     # If plot already has a facet, do not override it


### PR DESCRIPTION
Return geom_pop's internally computed df_pop in the ggpop_geom_pop object and use it in ggplot_add: set plot$data to df_pop, clear the consumed "icon" mapping, and default plot mappings x/y to x1/y1 when not provided. This lets downstream geoms (e.g. geom_text/geom_label) inherit the computed coordinates without users having to re-specify x/y.

Issue: #341

Version: #265