### PR TITLE
Release ggpop v1.7.1 to CRAN

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,5 @@
 ^vignettes/\.quarto$
 ^vignettes/articles$
 ^CITATION\.cff$
+^doc$
+^Meta$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,48 @@
+on:
+  push:
+    branches: [main, Dev]
+  pull_request:
+    branches: [main, Dev]
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,  r: 'release'}
+          - {os: ubuntu-latest,  r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: ggpop
 Title: Icon-Based Population Charts and Plots for 'ggplot2'
-Version: 1.7.0
-Date: 2026-03-06
+Version: 1.7.1
+Date: 2026-03-18
 Authors@R: c(
     person(given = "Jorge A.",
              family = "Roa-Contreras",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,8 +39,7 @@ Suggests:
     ggrepel,
     ggtext,
     scales,
-    reactable,
-    reactablefmtr
+    reactable
 Config/Needs/website: sf, geofacet, ggtext, quarto
 Config/testthat/edition: 3
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Authors@R: c(
              role = c("aut"),
              email = "cpinedaa@uw.edu",
              comment = c(ORCID = "0000-0002-8352-7080")))
-Description: Create visually engaging and informative population charts in R. 'ggpop' allows users to represent population data proportionally using customizable icons, facilitating the creation of circular representative population charts. Icon rendering builds on the layered grammar of graphics described in Wickham (2010) <doi:10.1198/jcgs.2009.07098>.
+Description: Create visually engaging and informative population charts in R. 'ggpop' allows users to represent population data proportionally using customizable icons, facilitating the creation of circular representative population charts.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Authors@R: c(
              role = c("aut"),
              email = "cpinedaa@uw.edu",
              comment = c(ORCID = "0000-0002-8352-7080")))
-Description: Create visually engaging and informative population charts in R. 'ggpop' allows users to represent population data proportionally using customizable icons, facilitating the creation of circular representative population charts.
+Description: Create engaging population and point plots charts in R. 'ggpop' allows users to represent population data and points proportionally using customizable icons, facilitating the creation of circular representative population charts as well as any point-plots.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# ggpop 1.7.1
+
+## Bug Fixes
+
+- Fixed a CRAN NOTE caused by `fetch_df_coordinates()` writing a cache file to `~/.cache/R/ggpop/` during package checks. The function now uses `tempdir()` when running on CRAN and the persistent user cache only when `NOT_CRAN=true`.
+
 # ggpop 1.7.0
 
 This release of `ggpop` delivers new theming support, expanded icon customization, critical bug fixes, and significant internal refactoring toward a fully ggplot-native architecture. Deprecated functionality has been removed and the package has been finalized.

--- a/R/fetch_df_coordinates.R
+++ b/R/fetch_df_coordinates.R
@@ -23,8 +23,12 @@
 #' @export
 
 fetch_df_coordinates <- function() {
-  cache_dir <- tools::R_user_dir("ggpop", which = "cache")
-  dir.create(cache_dir, showWarnings = FALSE, recursive = TRUE)
+  if (identical(Sys.getenv("NOT_CRAN"), "true")) {
+    cache_dir <- tools::R_user_dir("ggpop", which = "cache")
+    dir.create(cache_dir, showWarnings = FALSE, recursive = TRUE)
+  } else {
+    cache_dir <- tempdir()
+  }
   cache_file <- file.path(cache_dir, "df_coordinates_final_10_1000.rda")
 
   if (!file.exists(cache_file)) {

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,28 @@
+## R CMD check results
+
+0 errors | 0 warnings | 0 notes
+
+## Patch notes (1.7.1)
+
+This is a patch release addressing a NOTE raised by CRAN after the 1.7.0 submission.
+
+### NOTE fixed
+
+`fetch_df_coordinates()` was writing a cache file to `~/.cache/R/ggpop/` during
+package checks, triggering:
+
+```
+* checking for new files in some other directories ... NOTE
+Found the following files/directories:
+  '~/.cache/R/ggpop'
+  '~/.cache/R/ggpop/df_coordinates_final_10_1000.rda'
+```
+
+The function now uses `tempdir()` when running on CRAN (`NOT_CRAN != "true"`) and
+the persistent user cache only in interactive/local sessions.
+
+## Test environments
+
+- macOS ARM64, R release (local)
+- GitHub Actions: macOS-latest, windows-latest, ubuntu-latest (R devel, release, oldrel-1)
+- CRAN win-builder (devel and release)


### PR DESCRIPTION
This pull request is a patch release (v1.7.1) focused on fixing a CRAN NOTE related to cache file creation during package checks. It also updates the package description, adjusts some dependencies, and introduces a GitHub Actions workflow for automated R CMD checks. Below are the most important changes:

**CRAN compliance and bug fix:**
* Modified `fetch_df_coordinates()` to use `tempdir()` for caching when running on CRAN, preventing the creation of persistent cache files that triggered a CRAN NOTE. Persistent user cache is now only used when `NOT_CRAN=true`. (`R/fetch_df_coordinates.R`, `NEWS.md`, `cran-comments.md`) [[1]](diffhunk://#diff-fc4315fb3607ba36767eb80308ab7ea4f9ed1398467f3feffb59389f9673fe02R26-R31) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR1-R6) [[3]](diffhunk://#diff-cf8c1cd4cfb6a9ceb5ba522a5711321831948fea41fbb0cd9f799506c7caca1bR1-R28)

**Continuous integration:**
* Added a GitHub Actions workflow (`R-CMD-check.yaml`) to automatically run R CMD checks on multiple operating systems and R versions for pushes and pull requests to `main` and `Dev` branches. (`.github/workflows/R-CMD-check.yaml`)

**Documentation and metadata updates:**
* Bumped package version to 1.7.1 and updated the release date. (`DESCRIPTION`)
* Updated the package description to clarify that `ggpop` supports both population and point plot charts. (`DESCRIPTION`)
* Updated `cran-comments.md` with details about the NOTE fix and testing environments.

**Dependency management:**
* Removed `reactablefmtr` from the suggested packages list in `DESCRIPTION`. (`DESCRIPTION`)

**Build configuration:**
* Updated `.Rbuildignore` to exclude `doc` and `Meta` directories from the build. (`.Rbuildignore`)

# ggpop 1.7.1

## Bug Fixes

- Fixed a CRAN NOTE caused by `fetch_df_coordinates()` writing a cache file to `~/.cache/R/ggpop/` during package checks. The function now uses `tempdir()` when running on CRAN and the persistent user cache only when `NOT_CRAN=true`.


Version: #376 