### PR TITLE
Polish README, bump to 1.8.0, and add icon shadow warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Authors@R: c(
              role = c("aut"),
              email = "cpinedaa@uw.edu",
              comment = c(ORCID = "0000-0002-8352-7080")))
-Description: Create engaging population and point plots charts in R. 'ggpop' allows users to represent population data and points proportionally using customizable icons, facilitating the creation of circular representative population charts as well as any point-plots.
+Description: Create engaging population charts and point plots in R. 'ggpop' allows users to represent population data and points proportionally using customizable icons, facilitating the creation of circular representative population charts as well as any point-plots.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: ggpop
 Title: Icon-Based Population Charts and Plots for 'ggplot2'
-Version: 1.7.1
-Date: 2026-03-18
+Version: 1.8.0
+Date: 2026-06-21
 Authors@R: c(
     person(given = "Jorge A.",
              family = "Roa-Contreras",

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## New features
 
 - `geom_pop()` and `geom_icon_point()` now accept custom SVG icons in addition to Font Awesome names. The `icon` aesthetic (or the `icon` parameter) resolves, in priority order, to: a local `.svg` path; a file in your own icon folder (via the new `icon_path` argument or `options(ggpop.icon_path = "<dir>")`), referenced by name just like a Font Awesome icon; a bundled ggpop marker (e.g. `"square-inset"`, `"circle-cross"`, `"diamond-hollow"`); or a Font Awesome name. Monochrome SVGs are recoloured by the mapped colour aesthetic, content-hash cached, and rendered crisply at any `dpi` in both the plot body and the legend keys. An unrecognised name now raises a clear error instead of a cryptic Font Awesome failure (#383).
+- `geom_pop()` and `geom_icon_point()` now warn at construction time when any SVG file in `icon_path` shares a name with a Font Awesome icon, listing the shadowed names and suggesting a rename to avoid silent conflicts (#383).
 - `ggpop_markers()` lists the bundled marker names (and the names found in an `icon_path` folder) - the companion to `fa_icons()` (#383).
 - `marker_legend()` builds a standalone composite legend of icon markers - multiple columns, mixed icon sources (Font Awesome, bundled markers, or your own SVGs), and room for extra annotations - for cases that ggplot2's built-in guides cannot express. For an ordinary data-driven legend, keep using `legend_icons = TRUE` with `scale_legend_icon()` (#385).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 - `geom_pop()` and `geom_icon_point()` now accept custom SVG icons in addition to Font Awesome names. The `icon` aesthetic (or the `icon` parameter) resolves, in priority order, to: a local `.svg` path; a file in your own icon folder (via the new `icon_path` argument or `options(ggpop.icon_path = "<dir>")`), referenced by name just like a Font Awesome icon; a bundled ggpop marker (e.g. `"square-inset"`, `"circle-cross"`, `"diamond-hollow"`); or a Font Awesome name. Monochrome SVGs are recoloured by the mapped colour aesthetic, content-hash cached, and rendered crisply at any `dpi` in both the plot body and the legend keys. An unrecognised name now raises a clear error instead of a cryptic Font Awesome failure (#383).
 - `ggpop_markers()` lists the bundled marker names (and the names found in an `icon_path` folder) - the companion to `fa_icons()` (#383).
+- `marker_legend()` builds a standalone composite legend of icon markers - multiple columns, mixed icon sources (Font Awesome, bundled markers, or your own SVGs), and room for extra annotations - for cases that ggplot2's built-in guides cannot express. For an ordinary data-driven legend, keep using `legend_icons = TRUE` with `scale_legend_icon()` (#385).
 
 # ggpop 1.7.2
 

--- a/R/geom_icon_point.R
+++ b/R/geom_icon_point.R
@@ -102,6 +102,7 @@ geom_icon_point <- function(mapping = NULL, data = NULL, stat = "identity",
 
   # 05 Warnings for potential conflicts ----
 
+  warn_icon_path_shadows_fa(icon_path %||% getOption("ggpop.icon_path", NULL))
   validate_stroke_width_not_aesthetic(combined_mapping)
   validate_literal_alpha_in_aes(combined_mapping, data = data)
   warn_size_conflict(combined_mapping, .missing_size, size)

--- a/R/geom_pop.R
+++ b/R/geom_pop.R
@@ -178,6 +178,7 @@ geom_pop <- function(mapping = NULL, data = NULL, stat = "identity",
 
   # 07 Warnings (shared) ----
 
+  warn_icon_path_shadows_fa(icon_path %||% getOption("ggpop.icon_path", NULL))
   warn_all_geom_pop(
     combined_mapping = combined_mapping,
     missing_size = .missing_size,

--- a/R/icon-utils.R
+++ b/R/icon-utils.R
@@ -190,6 +190,23 @@ fa_icon_names <- function() {
   .ggpop_cache$fa_names
 }
 
+warn_icon_path_shadows_fa <- function(icon_path) {
+  if (is.null(icon_path) || !nzchar(icon_path) || !dir.exists(icon_path)) {
+    return(invisible(NULL))
+  }
+  svgs <- tools::file_path_sans_ext(
+    basename(list.files(icon_path, pattern = "\\.svg$", ignore.case = TRUE))
+  )
+  shadowed <- intersect(svgs, fa_icon_names())
+  if (length(shadowed) == 0L) return(invisible(NULL))
+  cli::cli_warn(c(
+    "{length(shadowed)} icon name{?s} in {.arg icon_path} shadow Font Awesome name{?s}.",
+    "x" = "Shadowed: {.val {shadowed}}.",
+    "i" = "These will resolve to your SVG files, not Font Awesome icons.",
+    "i" = "Rename the file{?s} (e.g. {.val my-{shadowed[[1]]}.svg}) to avoid the conflict."
+  ))
+}
+
 resolve_icon_source <- function(icon, icon_path = NULL) {
   icon <- as.character(icon)
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![R-CMD-check](https://github.com/jurjoroa/ggpop/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/jurjoroa/ggpop/actions/workflows/R-CMD-check.yaml)
 [![pages-build-deployment](https://github.com/jurjoroa/ggpop/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/jurjoroa/ggpop/actions/workflows/pages/pages-build-deployment)
 [![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
+[![minimal R version](https://img.shields.io/badge/R%3E%3D-4.0.5-blue.svg)](https://cran.r-project.org/)
 [![CRAN downloads](https://cranlogs.r-pkg.org/badges/ggpop)](https://CRAN.R-project.org/package=ggpop)
 [![CRAN total downloads](https://cranlogs.r-pkg.org/badges/grand-total/ggpop)](https://CRAN.R-project.org/package=ggpop)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -16,6 +17,14 @@
 > **Turn numbers into people. Turn data into stories.**
 
 `ggpop` is an R package built on top of ggplot2 that simplifies the creation of icon-based population charts. By combining features from `ggplot2` and `ggimage`, `ggpop` lets users visualize population data using customizable icons arranged in circular layouts. Designed primarily for visual storytelling, ggpop helps users communicate population statistics in an appealing manner.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/example_plot2.png" width="46%" alt="geom_pop(): Mexico population by sex, drawn as icons" />
+  <img src="https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/food_calories_protein.png" width="46%" alt="geom_icon_point(): calories vs protein by food group, drawn as icons" />
+</p>
+<p align="center"><sub><code>geom_pop()</code> — proportional population charts&nbsp;&nbsp;·&nbsp;&nbsp;<code>geom_icon_point()</code> — icon scatter plots</sub></p>
+
+> **New in 1.8.0** — custom SVG icons beyond Font Awesome (`ggpop_markers()`, `icon_path`) and `marker_legend()` for standalone composite legends. See the [Legends article](https://jurjoroa.github.io/ggpop/articles/marker-legend.html).
 
 
 ## An Alternative Approach to Visualization
@@ -56,22 +65,6 @@ Development version of the package can be installed from
 install.packages("remotes")
 remotes::install_github("jurjoroa/ggpop")
 ```
-
-## Key Functions & Parameters
-
-| Function / Parameter | Purpose |
-|:---|:---|
-| `process_data()` | Convert group counts → one row per icon; use `high_group_var` for independent per-group sampling (e.g. for faceted charts) |
-| `fa_icons()` | Search 2,000+ Font Awesome icons from your R console |
-| `theme_pop()` | Built-in minimal theme (also `theme_pop_dark()`, `theme_pop_minimal()`) |
-| `scale_legend_icon()` | Resize legend icons independently of the plot icons |
-| `ggpop_markers()` | List bundled SVG markers (and your own via `icon_path`) usable as icons |
-| `marker_legend()` | Build a standalone composite legend of icon markers (multi-column, mixed sources) |
-| `arrange` | `geom_pop()` parameter — cluster icons by group (`TRUE`) or scatter randomly (`FALSE`, default) |
-| `stroke_width` | `geom_pop()` parameter — add an outline to every icon, in pixels (e.g. `stroke_width = 1`) |
-| `seed` | `geom_pop()` parameter — fix the random icon layout for reproducible charts (e.g. `seed = 42`) |
-
-
 
 ## `geom_pop()` — Population Charts
 
@@ -139,22 +132,32 @@ df_pop_mx_prop <- df_pop_mx_prop %>%
 
 ### 4.- Icons
 
-<p style="display: flex; align-items: center;">
-  <img src="inst/figures/logo.png" width="115px" alt="Logo" />
-  <img src="https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/fontawesome.svg" width="115px" alt="Fontawesome" />
-</p>
+<table>
+<tr>
+<td valign="top" width="56%">
+Whatever you map to <code>icon</code> can come from three sources — and you can mix them in a single plot:
+<ul>
+<li><b>Font Awesome</b> (2,000+) — the icon name, e.g. <code>"user"</code>; find names with <code>fa_icons()</code></li>
+<li><b>Bundled <code>ggpop</code> markers</b> — e.g. <code>"square-inset"</code>; list them with <code>ggpop_markers()</code></li>
+<li><b>Your own SVGs</b> — a file in your <code>icon_path</code> folder, or a direct <code>.svg</code> path</li>
+</ul>
+A sample of Font Awesome names:<br><br>
+<code>home</code> · <code>user</code> · <code>envelope</code> · <code>bell</code> · <code>camera</code> · <code>cog</code> · <code>heart</code> · <code>calendar</code> · <code>check</code> · <code>cloud</code> · <code>comment</code> · <code>download</code> · <code>flag</code> · <code>folder</code> · <code>phone</code>
+</td>
+<td valign="top" width="44%">
+<img src="https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/fontawesome_icons.png" width="100%" alt="Font Awesome icon table preview" />
+</td>
+</tr>
+</table>
 
-Icon names come from the `fontawesome` package. A sample of available icons:
-
-`home` · `user` · `envelope` · `bell` · `camera` · `cog` · `heart` · `calendar` · `cart-plus` · `check` · `cloud` · `comment` · `download` · `edit` · `file` · `filter` · `flag` · `folder` · `phone`
-
-<p align="center"><img src="https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/fontawesome_icons.png" width="70%" alt="fontawesome table preview" /></p>
-
-Search from R with `fa_icons()` or browse the [Font Awesome gallery](https://fontawesome.com/icons):
+Search from R, or browse the [Font Awesome gallery](https://fontawesome.com/icons):
 
 ``` r
-fa_icons(query = "person")
+fa_icons(query = "person")   # search Font Awesome names
+ggpop_markers()              # list bundled markers (and your own via icon_path)
 ```
+
+> Custom SVGs and bundled markers are new in 1.8.0 — see the [Legends & custom markers article](https://jurjoroa.github.io/ggpop/articles/marker-legend.html).
 
 ### 5.- Plot population chart
 
@@ -171,6 +174,9 @@ ggplot() +
 ![Example Plot](https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/example_plot1.png)
 
 #### 5.1 Improve the plot
+
+<details>
+<summary><b>Show the full styling code</b></summary>
 
 ``` r
 ggplot(data = df_pop_mx_prop, aes(icon = icon, color = type)) +
@@ -193,9 +199,14 @@ ggplot(data = df_pop_mx_prop, aes(icon = icon, color = type)) +
                      labels = c("female" = "Females: 51%", "male" = "Males: 49%"))
 ```
 
+</details>
+
 ![Example Plot](https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/example_plot2.png)
 
 Multiple icon types in the same plot:
+
+<details>
+<summary><b>Show the full styling code</b></summary>
 
 ``` r
 #1.- We load or create the data
@@ -255,6 +266,8 @@ ggplot(data = df_pop_dis_mx_prop, aes(icon = icon, color = type)) +
                                 "disabled males" = "Disabled Males"))
 ```
 
+</details>
+
 ![Example Plot 3](https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/example_plot3.png)
 
 ---
@@ -313,6 +326,9 @@ ggplot(df_food, aes(x = calories, y = protein, icon = icon, color = food)) +
 
 Icon size mapped to number of employees.
 
+<details>
+<summary><b>Show the full styling code</b></summary>
+
 ``` r
 library(ggplot2)
 library(ggpop)
@@ -354,6 +370,8 @@ ggplot(df_brand, aes(x = revenue, y = market_cap,
 
 ```
 
+</details>
+
 ![Tech Brand Revenue vs. Market Cap](https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/tech_brands_revenue_marketcap.png)
 
 ### Featured Example: Cost-Effectiveness of Health Spending
@@ -363,6 +381,71 @@ ggplot(df_brand, aes(x = revenue, y = market_cap,
 **[Code available in ggpop package website](https://jurjoroa.github.io/ggpop/articles/examples-geom-icon-point.html#example-5-combined-geoms-in-cost-effectiveness-analysis)**.
 
 ![](https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/cea_icon_plot.png)
+
+---
+
+## Bring Your Own Icons
+
+Font Awesome is just the default. `ggpop` also renders **your own SVG files** and a set of **bundled markers** — anywhere an `icon` is expected, in both geoms *and* the legend.
+
+### Your own `.svg` files
+
+**1. Put your SVGs in a folder**, each file named however you want to reference it:
+
+```
+energy-icons/
+├── solar.svg
+├── wind.svg
+├── hydro.svg
+└── bioenergy.svg
+```
+
+**2. Reference each file by its bare name** — no `.svg`, no path, exactly like a Font Awesome icon — and point `ggpop` at the folder with `icon_path` (per layer) or `options(ggpop.icon_path = "energy-icons")` (whole session):
+
+``` r
+library(ggplot2)
+library(ggpop)
+
+df_energy <- data.frame(
+  source   = c("Solar", "Wind", "Hydro", "Bioenergy"),
+  icon     = c("solar", "wind", "hydro", "bioenergy"),  # = file names, without .svg
+  capacity = c(1410, 1020, 1400, 150),                  # installed capacity, GW
+  growth   = c(24, 13, 2, 6)                            # annual growth, %
+)
+
+ggplot(df_energy, aes(x = capacity, y = growth, icon = icon, colour = source)) +
+  geom_icon_point(size = 7, icon_path = "energy-icons", legend_icons = TRUE) +
+  scale_colour_manual(values = c(Solar = "#F4A300", Wind = "#2A9D8F",
+                                 Hydro = "#1E88E5", Bioenergy = "#6AA84F")) +
+  scale_legend_icon(size = 6) +
+  labs(title = "Renewable Electricity: Scale vs. Momentum",
+       x = "Installed capacity (GW)", y = "Annual growth (%)", colour = "Source") +
+  theme_minimal()
+```
+
+![Renewable electricity scatter drawn with four custom SVG icons](https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/readme-byo-icons.png)
+
+Your monochrome SVGs are recoloured per group **and** carried into the legend keys. For a one-off file you can also pass a **direct path**: `aes(icon = "path/to/special.svg")`.
+
+### Bundled markers
+
+`ggpop` ships a family of solid / outline markers (squares, circles, diamonds, plus a few extras) — added at the request of Claudia L. Seguin. List them and use any by name — no folder needed:
+
+``` r
+ggpop_markers()$bundled
+#>  [1] "circle-cross"   "circle-hollow"  "circle-inset"   "circle-solid"
+#>  [5] "diamond-cross"  "diamond-hollow" "diamond-inset"  "diamond-solid"
+#>  [9] "plus-bold"      "square-cross"   "square-hollow"  "square-inset"
+#> [13] "square-solid"   "triangle-down"
+```
+
+![The 14 bundled ggpop markers, grouped by shape family and recoloured](https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/bundled_markers.png)
+
+### Recolouring
+
+Monochrome SVGs — those drawn in a single colour (`#000000`, `currentColor`, or `fill="black"`) — are recoloured to the mapped `colour` aesthetic automatically, just like Font Awesome icons. Multi-colour SVGs render exactly as drawn.
+
+> **Resolution order** for any `icon` value: a readable `.svg` path → a file in `icon_path` → a bundled marker → a Font Awesome name → a clear error if none match. Full walkthrough in the [Legends & custom markers article](https://jurjoroa.github.io/ggpop/articles/marker-legend.html).
 
 ---
 
@@ -401,6 +484,21 @@ Animated Gapminder-style: life expectancy vs. GDP per capita across five decades
 
 ![Example gganimate animation](https://raw.githubusercontent.com/jurjoroa/ggpopdata/main/inst/figures/world_transformed.gif)
 ---
+
+## Key Functions & Parameters
+
+| Function / Parameter | Purpose |
+|:---|:---|
+| `process_data()` | Convert group counts → one row per icon; use `high_group_var` for independent per-group sampling (e.g. for faceted charts) |
+| `fa_icons()` | Search 2,000+ Font Awesome icons from your R console |
+| `ggpop_markers()` | List bundled SVG markers (and your own via `icon_path`) usable as icons |
+| `marker_legend()` | Build a standalone composite legend of icon markers (multi-column, mixed sources) |
+| `theme_pop()` | Built-in minimal theme (also `theme_pop_dark()`, `theme_pop_minimal()`) |
+| `scale_legend_icon()` | Resize legend icons independently of the plot icons |
+| `arrange` | `geom_pop()` parameter — cluster icons by group (`TRUE`) or scatter randomly (`FALSE`, default) |
+| `stroke_width` | `geom_pop()` parameter — add an outline to every icon, in pixels (e.g. `stroke_width = 1`) |
+| `seed` | `geom_pop()` parameter — fix the random icon layout for reproducible charts (e.g. `seed = 42`) |
+
 
 ## Citation
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,24 +2,22 @@
 
 0 errors | 0 warnings | 0 notes
 
-## Patch notes (1.7.1)
+## Release notes (1.8.0)
 
-This is a patch release addressing a NOTE raised by CRAN after the 1.7.0 submission.
+This is a minor feature release adding custom SVG icon support and a new
+composite legend function.
 
-### NOTE fixed
+### New features
 
-`fetch_df_coordinates()` was writing a cache file to `~/.cache/R/ggpop/` during
-package checks, triggering:
-
-```
-* checking for new files in some other directories ... NOTE
-Found the following files/directories:
-  '~/.cache/R/ggpop'
-  '~/.cache/R/ggpop/df_coordinates_final_10_1000.rda'
-```
-
-The function now uses `tempdir()` when running on CRAN (`NOT_CRAN != "true"`) and
-the persistent user cache only in interactive/local sessions.
+- `geom_pop()` and `geom_icon_point()` now accept custom SVG files via the
+  new `icon_path` argument (or `options(ggpop.icon_path)`). Icons resolve in
+  priority order: local `.svg` path → `icon_path` folder → bundled ggpop
+  marker → Font Awesome name.
+- 14 bundled solid/outline markers (`square-*`, `circle-*`, `diamond-*`,
+  `plus-bold`, `triangle-down`) are available by name with no folder needed.
+- `ggpop_markers()` lists bundled and user-provided marker names.
+- `marker_legend()` builds standalone composite legends for cases that
+  ggplot2's built-in guides cannot express.
 
 ## Test environments
 


### PR DESCRIPTION
## Summary
Prepares ggpop for the 1.8.0 release: full README restructure for
clarity and discoverability, version bump to 1.8.0, updated CRAN
submission notes, and a new construction-time warning when `icon_path`
SVG names shadow Font Awesome icons. Unblocks `release_JARC`.

## What changed
- `README.md`:
  - Package landing page and primary user-facing documentation
  - Full polish: hero montage, collapsible code blocks, two-column Icons
    section, BYO SVG section with energy demo, bundled markers gallery
    with Claudia L. Seguin attribution, R >= 4.0.5 badge, updated Key
    Functions table covering `ggpop_markers()` and `marker_legend()`
  - Reduces clutter before the first geom examples; improves onboarding
- `DESCRIPTION`:
  - Package metadata file
  - Version bumped from 1.7.1 to 1.8.0; Date updated to 2026-06-21
  - Required for CRAN submission
- `cran-comments.md`:
  - CRAN submission cover notes
  - Rewritten for 1.8.0: describes custom SVG, bundled markers, `marker_legend()`
  - Required by `devtools::submit_cran()` before submission
- `R/icon-utils.R`:
  - Internal icon resolution utilities
  - New `warn_icon_path_shadows_fa()` — scans `icon_path` folder,
    intersects with cached FA name set, emits `cli_warn` listing shadowed
    names with a concrete rename suggestion
  - Prevents silent icon substitution when user SVG names collide with FA
- `R/geom_pop.R` + `R/geom_icon_point.R`:
  - Both geom constructors
  - Call `warn_icon_path_shadows_fa()` in the Warnings section (07 / 05)
  - One-shot at construction time; silent when no conflicts
- `NEWS.md`:
  - Package changelog
  - Two new 1.8.0 bullets: `marker_legend()` and the icon shadow warning
  - Documents both additions for users upgrading to 1.8.0

---
Project: ggpop Date: 21-June-2026 3:27 PM PT
Branch: 387-polish-readme-docs → Base: Dev
Issue: #387 | Version: #381
