### PR TITLE
Redraw bundled SVG markers and polish marker_legend layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ docs
 /Meta/
 .claude/settings.local.json
 AGENTS.md
+R/example.R
+Rplots.pdf

--- a/R/marker_legend.R
+++ b/R/marker_legend.R
@@ -40,6 +40,8 @@
 #' @param row_spacing Vertical distance between rows.
 #' @param label_gap Horizontal gap between a marker and its label.
 #' @param label_colour Text colour for the labels (default: \code{"black"}).
+#' @param label_fontface Font face for the labels (default: \code{"plain"}).
+#'   Common values: \code{"plain"}, \code{"bold"}, \code{"italic"}.
 #' @param default_color Marker colour used for rows with no \code{colour} value.
 #'
 #' @return A \code{ggplot} object with \code{theme_void()} applied.
@@ -76,6 +78,7 @@ marker_legend <- function(entries,
                           row_spacing = 1,
                           label_gap = 0.6,
                           label_colour = "black",
+                          label_fontface = "plain",
                           default_color = "black") {
   layout <- match.arg(layout)
   validate_marker_legend_entries(entries, layout)
@@ -104,7 +107,8 @@ marker_legend <- function(entries,
       mapping = ggplot2::aes(x = x + label_gap, y = y, label = label),
       hjust = 0,
       size = label_size,
-      colour = label_colour
+      colour = label_colour,
+      fontface = label_fontface
     ) +
     ggplot2::scale_colour_identity() +
     ggplot2::theme_void()
@@ -120,7 +124,7 @@ marker_legend <- function(entries,
   p <- p +
     ggplot2::coord_cartesian(
       xlim = c(x_min - col_spacing * 0.2, x_max + col_spacing),
-      ylim = c(y_min - row_spacing, y_max + row_spacing * (if (has_title) 1.8 else 0.6)),
+      ylim = c(y_min - row_spacing, y_max + row_spacing * (if (has_title) 1.5 else 0.6)),
       clip = "off"
     )
 
@@ -128,12 +132,12 @@ marker_legend <- function(entries,
     p <- p +
       ggplot2::annotate(
         "text",
-        x = x_min,
-        y = y_max + row_spacing * 1.4,
+        x = (x_min + x_max + col_spacing * 0.8) / 2,
+        y = y_max + row_spacing * 0.85,
         label = title,
-        hjust = 0,
-        fontface = "bold",
-        size = label_size * 1.3,
+        hjust = 0.5,
+        fontface = "plain",
+        size = label_size,
         colour = label_colour
       )
   }

--- a/inst/icons/circle-cross.svg
+++ b/inst/icons/circle-cross.svg
@@ -1,3 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-<circle cx="50" cy="50" r="32" fill="none" stroke="#000000" stroke-width="9"/><rect x="18" y="45.5" width="64" height="9" fill="#000000"/><rect x="45.5" y="18" width="9" height="64" fill="#000000"/>
+<rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<defs>
+  <clipPath id="circle-cross-clip">
+    <circle cx="50" cy="50" r="42"/>
+  </clipPath>
+</defs>
+<g clip-path="url(#circle-cross-clip)">
+  <rect x="0" y="42" width="100" height="16" fill="#000000"/>
+  <rect x="42" y="0" width="16" height="100" fill="#000000"/>
+</g>
+<circle cx="50" cy="50" r="42" fill="none" stroke="#000000" stroke-width="16"/>
 </svg>

--- a/inst/icons/circle-hollow.svg
+++ b/inst/icons/circle-hollow.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
 <rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
 <rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
-<circle cx="50" cy="50" r="41" fill="none" stroke="#000000" stroke-width="18"/>
+<circle cx="50" cy="50" r="41" fill="none" stroke="#000000" stroke-width="12"/>
 </svg>

--- a/inst/icons/circle-hollow.svg
+++ b/inst/icons/circle-hollow.svg
@@ -1,3 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-<circle cx="50" cy="50" r="32" fill="none" stroke="#000000" stroke-width="9"/>
+<rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<circle cx="50" cy="50" r="41" fill="none" stroke="#000000" stroke-width="18"/>
 </svg>

--- a/inst/icons/circle-inset.svg
+++ b/inst/icons/circle-inset.svg
@@ -2,5 +2,5 @@
 <rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
 <rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
 <circle cx="50" cy="50" r="41" fill="none" stroke="#000000" stroke-width="14"/>
-<circle cx="50" cy="50" r="22" fill="#000000"/>
+<circle cx="50" cy="50" r="23" fill="#000000"/>
 </svg>

--- a/inst/icons/circle-inset.svg
+++ b/inst/icons/circle-inset.svg
@@ -1,3 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-<circle cx="50" cy="50" r="32" fill="none" stroke="#000000" stroke-width="9"/><circle cx="50" cy="50" r="12" fill="#000000"/>
+<rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<circle cx="50" cy="50" r="41" fill="none" stroke="#000000" stroke-width="14"/>
+<circle cx="50" cy="50" r="22" fill="#000000"/>
 </svg>

--- a/inst/icons/circle-solid.svg
+++ b/inst/icons/circle-solid.svg
@@ -1,3 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-<circle cx="50" cy="50" r="32" fill="#000000"/>
+<rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<circle cx="50" cy="50" r="41" fill="#000000"/>
 </svg>

--- a/inst/icons/diamond-cross.svg
+++ b/inst/icons/diamond-cross.svg
@@ -1,3 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-<polygon points="50,14 86,50 50,86 14,50" fill="none" stroke="#000000" stroke-width="9"/><rect x="20" y="45.5" width="60" height="9" fill="#000000"/><rect x="45.5" y="20" width="9" height="60" fill="#000000"/>
+<rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<path fill="#000000" fill-rule="evenodd" d="
+  M50 0 L100 50 L50 100 L0 50 Z
+  M50 18 L62 30 L50 42 L38 30 Z
+  M30 38 L42 50 L30 62 L18 50 Z
+  M70 38 L82 50 L70 62 L58 50 Z
+  M50 58 L62 70 L50 82 L38 70 Z"/>
 </svg>

--- a/inst/icons/diamond-hollow.svg
+++ b/inst/icons/diamond-hollow.svg
@@ -1,3 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-<polygon points="50,14 86,50 50,86 14,50" fill="none" stroke="#000000" stroke-width="9"/>
+<rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<path fill="#000000" fill-rule="evenodd" d="
+  M50 0 L100 50 L50 100 L0 50 Z
+  M50 17 L83 50 L50 83 L17 50 Z"/>
 </svg>

--- a/inst/icons/diamond-inset.svg
+++ b/inst/icons/diamond-inset.svg
@@ -4,5 +4,5 @@
 <path fill="#000000" fill-rule="evenodd" d="
   M50 0 L100 50 L50 100 L0 50 Z
   M50 17 L83 50 L50 83 L17 50 Z"/>
-<polygon points="50,28 72,50 50,72 28,50" fill="#000000"/>
+<polygon points="50,26 74,50 50,74 26,50" fill="#000000"/>
 </svg>

--- a/inst/icons/diamond-inset.svg
+++ b/inst/icons/diamond-inset.svg
@@ -1,3 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-<polygon points="50,14 86,50 50,86 14,50" fill="none" stroke="#000000" stroke-width="9"/><polygon points="50,32 68,50 50,68 32,50" fill="#000000"/>
+<rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<path fill="#000000" fill-rule="evenodd" d="
+  M50 0 L100 50 L50 100 L0 50 Z
+  M50 17 L83 50 L50 83 L17 50 Z"/>
+<polygon points="50,28 72,50 50,72 28,50" fill="#000000"/>
 </svg>

--- a/inst/icons/diamond-solid.svg
+++ b/inst/icons/diamond-solid.svg
@@ -1,3 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-<polygon points="50,14 86,50 50,86 14,50" fill="#000000"/>
+<rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<polygon points="50,0 100,50 50,100 0,50" fill="#000000"/>
 </svg>

--- a/inst/icons/plus-bold.svg
+++ b/inst/icons/plus-bold.svg
@@ -1,3 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-<rect x="45.5" y="12" width="9" height="76" fill="#000000"/><rect x="12" y="45.5" width="76" height="9" fill="#000000"/>
+<rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="41" y="0" width="18" height="100" fill="#000000"/>
+<rect x="0" y="41" width="100" height="18" fill="#000000"/>
 </svg>

--- a/inst/icons/square-cross.svg
+++ b/inst/icons/square-cross.svg
@@ -1,3 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-<rect x="18" y="18" width="64" height="64" fill="none" stroke="#000000" stroke-width="9"/><rect x="18" y="45.5" width="64" height="9" fill="#000000"/><rect x="45.5" y="18" width="9" height="64" fill="#000000"/>
+<rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<path fill="#000000" fill-rule="evenodd" d="
+  M10 10 H90 V90 H10 Z
+  M24 24 H43 V43 H24 Z
+  M57 24 H76 V43 H57 Z
+  M24 57 H43 V76 H24 Z
+  M57 57 H76 V76 H57 Z"/>
 </svg>

--- a/inst/icons/square-hollow.svg
+++ b/inst/icons/square-hollow.svg
@@ -1,3 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-<rect x="18" y="18" width="64" height="64" fill="none" stroke="#000000" stroke-width="9"/>
+<rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<path fill="#000000" fill-rule="evenodd" d="
+  M10 10 H90 V90 H10 Z
+  M24 24 H76 V76 H24 Z"/>
 </svg>

--- a/inst/icons/square-hollow.svg
+++ b/inst/icons/square-hollow.svg
@@ -3,5 +3,5 @@
 <rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
 <path fill="#000000" fill-rule="evenodd" d="
   M10 10 H90 V90 H10 Z
-  M24 24 H76 V76 H24 Z"/>
+  M22 22 H78 V78 H22 Z"/>
 </svg>

--- a/inst/icons/square-inset.svg
+++ b/inst/icons/square-inset.svg
@@ -1,3 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-<rect x="18" y="18" width="64" height="64" fill="none" stroke="#000000" stroke-width="9"/><rect x="36" y="36" width="28" height="28" fill="#000000"/>
+<rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<path fill="#000000" fill-rule="evenodd" d="
+  M10 10 H90 V90 H10 Z
+  M24 24 H76 V76 H24 Z"/>
+<rect x="32" y="32" width="36" height="36" fill="#000000"/>
 </svg>

--- a/inst/icons/square-solid.svg
+++ b/inst/icons/square-solid.svg
@@ -1,3 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-<rect x="18" y="18" width="64" height="64" fill="#000000"/>
+<rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="10" y="10" width="80" height="80" fill="#000000"/>
 </svg>

--- a/inst/icons/triangle-down.svg
+++ b/inst/icons/triangle-down.svg
@@ -1,3 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-<polygon points="16,30 84,30 50,86" fill="none" stroke="#000000" stroke-width="9" stroke-linejoin="round"/>
+<rect x="0" y="0" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<rect x="99" y="99" width="1" height="1" fill="#000000" fill-opacity="0.005"/>
+<polygon points="50,81 15,20 85,20" fill="none" stroke="#000000" stroke-width="18" stroke-linejoin="miter"/>
 </svg>


### PR DESCRIPTION
## Summary
Redraws all 12 bundled SVG marker icons from scratch to match their reference
shapes (solid, hollow, inset, cross variants for square, circle, diamond) with
visually consistent hollow-border thickness across all three shapes. Also adds
`label_fontface` to `marker_legend()` and tunes title spacing and weight for the
composite SDA legend layout.

## What changed
- `inst/icons/*.svg` (12 files — circle, square, diamond x solid/hollow/inset/cross; plus-bold, triangle-down):
  - Bundled SVG marker set rendered in ggpop composite legends
  - Redrawn with correct geometry per shape (evenodd paths for hollow/inset, stroke-width ring for circle-hollow)
  - Hollow borders now match visually across circle/square/diamond (~12 units perpendicular thickness)
  - Diamond-inset inner solid enlarged to radius 24 for better visual balance
- `R/marker_legend.R`:
  - Standalone composite legend builder for icon + label grids
  - Added `label_fontface` parameter (default `"plain"`) for callers needing bold/italic labels
  - Title fontface changed from bold to plain; y-position brought closer to the icon grid
  - Enables the SDA screening legend to homogenize all text to plain weight
- `.gitignore`:
  - Git ignore rules for the ggpop repo
  - Added `R/example.R` (working legend script) and `Rplots.pdf` to prevent accidental commits
  - Keeps the repo clean without losing the local working script

---
Project: ggpop Date: 23-June-2026 11:55 AM PT
Branch: 383-fix-bundled-svg-marker-shapes -> Base: Dev
Issue: #383 | Version: #381
